### PR TITLE
Change add_theta to addTheta in Location2D

### DIFF
--- a/model_obj/Location2D.m
+++ b/model_obj/Location2D.m
@@ -26,14 +26,16 @@ classdef Location2D
             %This function takes in an nx2 array of coordinates of the form
             %[x,y] and returns rotated and translated coordinates. The
             %translation and rotation are described by obj.anchor_xy and
-            %obj.theta. The optional "add_theta" argument adds an
-            %additional angle of "add_theta" to the obj.theta attribute.
+            %obj.theta. The optional "addTheta" argument adds an
+            %additional angle of "addTheta" to the obj.theta attribute.
             
-            if exist('add_theta','var')
+            validateattributes(coords, {'DimLinear'},{})
+            
+            if exist('addTheta','var')
                 validateattributes(addTheta, {'DimAngular'}, {'size',[1,1]})
-                add_theta = addTheta.toRadians() + obj.theta.toRadians();
-                T = [ cos(add_theta), -sin(add_theta); ...
-                      sin(add_theta),  cos(add_theta) ];
+                addTheta = addTheta.toRadians() + obj.theta.toRadians();
+                T = [ cos(addTheta), -sin(addTheta); ...
+                      sin(addTheta),  cos(addTheta) ];
             else
                 T = obj.R;
             end


### PR DESCRIPTION
I believe the Location2D should be fixed now but I cannot tell for sure because we need to add multiplication of a double and dimensional quantity to the operator overloading.