### PR TITLE
Add multiplication with non-dimensional scalar to operator overloads.

### DIFF
--- a/model_obj/dimensions/DimLinear.m
+++ b/model_obj/dimensions/DimLinear.m
@@ -18,6 +18,17 @@ classdef DimLinear < DimBase
             r = feval(class(lhs), DimMillimeter(sum));
         end
         
+        function r = mtimes(lhs, rhs)
+            validateattributes(lhs, {'double'}, {'nonempty'});
+            validateattributes(rhs, {'DimLinear'}, {'nonempty'});
+
+            % Convert to DimMillimeter for calculation
+            product = lhs*double(rhs.toMillimeter());
+
+            % Return object of same type as LHS
+            r = feval(class(rhs), DimMillimeter(product));
+        end
+        
         function r = minus(lhs, rhs)
             validateattributes(lhs, {'DimLinear'}, {'nonempty'});
             validateattributes(rhs, {'DimLinear'}, {'nonempty'});


### PR DESCRIPTION
The following situation will work:
```
a = DimMillimeter(2)
b = 2*a  %b will be a DimMillimeter object
```
The following will NOT work and will throw an error:
```
a = DimMillimeter(2)
b = a*2  % non-dimensional scalar cannot come after DimLinear object
```