### PR TITLE
Update tests to ensure comparison is using double types

### DIFF
--- a/tests/dimConstructorTest.m
+++ b/tests/dimConstructorTest.m
@@ -7,16 +7,16 @@ tol = 1e-5;
 val = DimMillimeter(DimInch(1));
 expected = DimMillimeter(25.4);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = DimMillimeter(DimMillimeter(DimMillimeter(25.4)));
 expected = DimMillimeter(25.4);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = DimInch(DimMillimeter(DimInch(25.4)));
 expected = DimInch(25.4);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);

--- a/tests/dimDivideTest.m
+++ b/tests/dimDivideTest.m
@@ -13,25 +13,25 @@ tol = 1e-5;
 val = oneInch / 2;
 expected = DimInch(0.5);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = oneMillimeter / 2;
 expected = DimMillimeter(0.5);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = oneMillimeter / -5;
 expected = DimMillimeter(-0.2);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = twoInches / 8;
 expected = DimInch(0.25);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 %% Test 2: mrdivide of two DimLinear gets scalar ratio
@@ -39,17 +39,17 @@ assert(abs(val - expected) < tol);
 val = oneInch / oneInch;
 expected = 1;
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = twoMillimeters / oneMillimeter;
 expected = 2;
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = oneInch / twoMillimeters;
 expected = 12.7;
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 

--- a/tests/dimLinearPlusTest.m
+++ b/tests/dimLinearPlusTest.m
@@ -13,25 +13,25 @@ tol = 1e-5;
 val = oneInch + oneInch;
 expected = DimInch(2);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = oneInch + twoInches;
 expected = DimInch(3);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = oneMillimeter + oneMillimeter;
 expected = DimMillimeter(2);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = oneMillimeter + twoMillimeters;
 expected = DimMillimeter(3);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 
@@ -40,23 +40,23 @@ assert(abs(val - expected) < tol);
 val = oneInch + oneMillimeter;
 expected = DimInch(1.0393701);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = oneInch + oneMillimeter + oneMillimeter;
 expected = DimInch(1.0787402);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = oneMillimeter + oneInch;
 expected = DimMillimeter(26.4);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = twoMillimeters + twoInches;
 expected = DimMillimeter(52.8);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 

--- a/tests/dimMtimesTest.m
+++ b/tests/dimMtimesTest.m
@@ -13,25 +13,25 @@ tol = 1e-5;
 val = 2 * oneInch;
 expected = DimInch(2);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = 2 * oneMillimeter;
 expected = DimMillimeter(2);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = 0 * oneMillimeter;
 expected = DimMillimeter(0);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = -2 * oneMillimeter;
 expected = DimMillimeter(-2);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 %% Test 2: mtimes of scalar on RHS
@@ -39,22 +39,22 @@ assert(abs(val - expected) < tol);
 val = oneInch * 2;
 expected = DimInch(2);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = oneMillimeter * 2;
 expected = DimMillimeter(2);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = oneMillimeter * 0;
 expected = DimMillimeter(0);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = oneMillimeter * -2;
 expected = DimMillimeter(-2);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);

--- a/tests/dimUminusTest.m
+++ b/tests/dimUminusTest.m
@@ -16,23 +16,23 @@ tol = 1e-5;
 val = -oneInch;
 expected = DimInch(-1);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = -twoInches;
 expected = DimInch(-2);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = -oneMillimeter;
 expected = DimMillimeter(-1);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = -two54Millimeters;
 expected = DimMillimeter(-254);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 

--- a/tests/dimUplusTest.m
+++ b/tests/dimUplusTest.m
@@ -16,23 +16,23 @@ tol = 1e-5;
 val = +negOneInch;
 expected = DimInch(1);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = +negTwoInches;
 expected = DimInch(2);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = +negOneMillimeter;
 expected = DimMillimeter(1);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 
 
 val = +neg254Millimeters;
 expected = DimMillimeter(254);
 assert(strcmp(class(val), class(expected)));
-assert(abs(val - expected) < tol);
+assert(abs(double(val) - double(expected)) < tol);
 


### PR DESCRIPTION
This doesn't really change anything, just a sanity check. The code prior to change could be using the overloaded `-` operator, which is not desired.