### PR TITLE
Add getParameter, setParameter, makeComponentInALine, makeMotionComponent functions

### DIFF
--- a/python/tools/magnet/DrawCircleSquare.py
+++ b/python/tools/magnet/DrawCircleSquare.py
@@ -1,0 +1,26 @@
+
+from win32com.client import DispatchEx  #module needed for opening MagNet
+
+MN = DispatchEx("MagNet.Application")   #open MagNet
+MN.Visible = True                       #make the MagNet window visible
+
+#Get Handles to MAGNET Scripting Interfaces
+Doc = MN.newDocument()                  
+View = Doc.getView()
+
+#define function for drawing circles x,y are the coordinates of the centre, r is radius
+def DrawCircle(x, y, r):
+    View.newCircle(x, y, r)
+#define function for drawing sqaures x,y are the coordinates of the centre, l is side length
+def DrawSquare(x, y, l):
+    View.newLine(x-l/2,y-l/2,x+l/2,y-l/2)
+    View.newLine(x+l/2,y-l/2,x+l/2,y+l/2)
+    View.newLine(x+l/2,y+l/2,x-l/2,y+l/2)
+    View.newLine(x-l/2,y+l/2,x-l/2,y-l/2)
+
+DrawCircle(0, 0, 50)
+
+DrawSquare(0, 0, 30)
+
+    
+View.viewAll() #zoom out to view whole geometry

--- a/python/tools/magnet/MagnetFunc.py
+++ b/python/tools/magnet/MagnetFunc.py
@@ -1,11 +1,10 @@
-# -*- coding: utf-8 -*-
 """
 Created on Thu Oct  1 14:07:59 2020
 
-@author: Ramadas
+@author: Bharat
 """
-#Needed at the beginning to use pywin32 to call ActiveX compliant programs as COM automation servers
-from win32com.client import DispatchEx 
+
+from win32com.client import DispatchEx  #module needed for opening MagNet
 
 def launch():
     MN = DispatchEx("MagNet.Application")   #open MagNet
@@ -27,40 +26,15 @@ def drawCircle(View, x, y, r):
     
 def selectSection(View, MNConsts, x, y):
     #select section containing coordinate (x,y)
-    View.selectAt(x, y, MNConsts.infoSetSelection)
+    View.selectAt(x, y, MNConsts.infoSetSelection, [MNConsts.infoSliceSurface])
 
-'''
-def makeComponentInALine(View, MNConsts, sweepDist, sectionName, material, flag=5):
-    if flag ==1:
-        View.makeComponentInALine(sweepDist, sectionName, "Name="+material, MNConsts.infoMakeComponentUnionSurfaces)
-    elif flag ==2:
-        View.makeComponentInALine(sweepDist, sectionName, "Name="+material, MNConsts.infoMakeComponentIgnoreHoles)
-    elif flag ==3:
-        View.makeComponentInALine(sweepDist, sectionName, "Name="+material, MNConsts.infoMakeComponentRemoveVertices)
-    elif flag ==4:
-        View.makeComponentInALine(sweepDist, sectionName, "Name="+material, MNConsts.infoMakeComponentUnionSurfaces or 
-                                  MNConsts.infoMakeComponentIgnoreHoles)
-    elif flag ==5:
-        View.makeComponentInALine(sweepDist, sectionName, "Name="+material, MNConsts.infoMakeComponentUnionSurfaces or 
-                                  MNConsts.infoMakeComponentRemoveVertices)
-    elif flag ==6:
-        View.makeComponentInALine(sweepDist, sectionName, "Name="+material, MNConsts.infoMakeComponentIgnoreHoles or 
-                                  MNConsts.infoMakeComponentRemoveVertices)
-    else:
-        View.makeComponentInALine(sweepDist, sectionName, "Name="+material, MNConsts.infoMakeComponentUnionSurfaces or 
-                                  MNConsts.infoMakeComponentIgnoreHoles or MNConsts.infoMakeComponentRemoveVertices)       
-'''
 
-def makeComponentInALine(MN, MNConsts, sweepDist, sectionName, material):
+def makeComponentInALine(View, MNConsts, sweepDist, ArrayOfValues, material):
     '''command to extrude a selected section by 'sweepDis't and assign to the component the 'sectionName' and 'material' 
     as specified, returns 0 if extrusion is succesful, 1 if extrusion failed'''
-    MN.processCommand("REDIM ArrayOfValues(0)")
-    MN.processCommand("ArrayOfValues(0) = \"{}\"".format(sectionName))
-    MN.processCommand("ret = getDocument.getView.makeComponentInALine({}, ArrayOfValues, \"Name={}\")"
-                      .format(sweepDist,material))
-    MN.processCommand("Call setVariant(0, ret)")    
-    err = MN.getVariant(0)
-    return err
+    y = View.makeComponentInALine(sweepDist, ArrayOfValues, "Name="+material, MNConsts.infoMakeComponentUnionSurfaces 
+                                  or MNConsts.infoMakeComponentRemoveVertices)
+    return y
 
 
 def makeSimpleCoil(Doc, ProblemID, ArrayOfValues):
@@ -88,3 +62,13 @@ def makeMotionComponent(Doc,ArrayOfValues):
     #makes a Motion component of 'ArrayOfValues', returns path of the Motion component
     motion = Doc.makeMotionComponent(ArrayOfValues)
     return motion
+
+def getParameter(MN, path, parameter):
+    MN.processCommand("REDIM strArray(0)")
+    MN.processCommand("DIM pType")
+    MN.processCommand("pType = getDocument.getParameter(\"{}\", \"{}\", strArray)".format(path,parameter))
+    MN.processCommand('Call setVariant(0, strArray,"PYTHON")')    
+    param = MN.getVariant(0,"PYTHON")
+    MN.processCommand('Call setVariant(0, pType,"PYTHON")')    
+    param_type = MN.getVariant(0,"PYTHON")
+    return param, param_type

--- a/python/tools/magnet/MagnetFunc.py
+++ b/python/tools/magnet/MagnetFunc.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Oct  1 14:07:59 2020
+
+@author: Ramadas
+"""
+#Needed at the beginning to use pywin32 to call ActiveX compliant programs as COM automation servers
+from win32com.client import DispatchEx 
+
+def launch():
+    MN = DispatchEx("MagNet.Application")   #open MagNet
+    MN.Visible = True                       #make the MagNet window visible
+    return MN
+
+def init(MN):
+    #Get Handles to MAGNET Scripting Interfaces
+    Doc = MN.newDocument()                  
+    View = Doc.getView()
+    Circuit = Doc.getCircuit()
+    MNConsts = MN.getConstants() 
+    return Doc, View, Circuit, MNConsts
+
+def drawCircle(View, x, y, r):
+    #draw circle with x,y as the coordinates of the centre, r as the radius
+    View.newCircle(x, y, r)
+    View.viewAll()
+    
+def selectSection(View, MNConsts, x, y):
+    #select section containing coordinate (x,y)
+    View.selectAt(x, y, MNConsts.infoSetSelection)
+
+'''
+def makeComponentInALine(View, MNConsts, sweepDist, sectionName, material, flag=5):
+    if flag ==1:
+        View.makeComponentInALine(sweepDist, sectionName, "Name="+material, MNConsts.infoMakeComponentUnionSurfaces)
+    elif flag ==2:
+        View.makeComponentInALine(sweepDist, sectionName, "Name="+material, MNConsts.infoMakeComponentIgnoreHoles)
+    elif flag ==3:
+        View.makeComponentInALine(sweepDist, sectionName, "Name="+material, MNConsts.infoMakeComponentRemoveVertices)
+    elif flag ==4:
+        View.makeComponentInALine(sweepDist, sectionName, "Name="+material, MNConsts.infoMakeComponentUnionSurfaces or 
+                                  MNConsts.infoMakeComponentIgnoreHoles)
+    elif flag ==5:
+        View.makeComponentInALine(sweepDist, sectionName, "Name="+material, MNConsts.infoMakeComponentUnionSurfaces or 
+                                  MNConsts.infoMakeComponentRemoveVertices)
+    elif flag ==6:
+        View.makeComponentInALine(sweepDist, sectionName, "Name="+material, MNConsts.infoMakeComponentIgnoreHoles or 
+                                  MNConsts.infoMakeComponentRemoveVertices)
+    else:
+        View.makeComponentInALine(sweepDist, sectionName, "Name="+material, MNConsts.infoMakeComponentUnionSurfaces or 
+                                  MNConsts.infoMakeComponentIgnoreHoles or MNConsts.infoMakeComponentRemoveVertices)       
+'''
+
+def makeComponentInALine(MN, MNConsts, sweepDist, sectionName, material):
+    '''command to extrude a selected section by 'sweepDis't and assign to the component the 'sectionName' and 'material' 
+    as specified, returns 0 if extrusion is succesful, 1 if extrusion failed'''
+    MN.processCommand("REDIM ArrayOfValues(0)")
+    MN.processCommand("ArrayOfValues(0) = \"{}\"".format(sectionName))
+    MN.processCommand("ret = getDocument.getView.makeComponentInALine({}, ArrayOfValues, \"Name={}\")"
+                      .format(sweepDist,material))
+    MN.processCommand("Call setVariant(0, ret)")    
+    err = MN.getVariant(0)
+    return err
+
+
+def makeSimpleCoil(Doc, ProblemID, ArrayOfValues):
+    #function to make a simple coil with 'ArrayOfValues' and 'ProblemID', returns path to the coil
+    coil=Doc.makeSimpleCoil(ProblemID, ArrayOfValues)
+    return coil
+''' 
+def newCircuitWindow(Doc):
+    Doc.newCircuitWindow()
+    
+def insertCurrentSource(Doc, Circuit, x, y):
+    Circuit.insertCurrentSource(x, y)
+'''
+
+def setParameter(Doc, opath, param, value, MNConsts):
+    #sets parameter, 'param' of object with path 'opath' as 'value'
+    if type(value) is str:
+        Doc.setParameter(opath, param, value, MNConsts.infoStringParameter)
+    elif type(value) is int:
+        Doc.setParameter(opath, param, str(value), MNConsts.infoNumberParameter)
+    elif type(value) is list:
+        Doc.setParameter(opath, param, str(value), MNConsts.infoArrayParameter)
+    
+def makeMotionComponent(Doc,ArrayOfValues):
+    #makes a Motion component of 'ArrayOfValues', returns path of the Motion component
+    motion = Doc.makeMotionComponent(ArrayOfValues)
+    return motion

--- a/python/tools/magnet/example.py
+++ b/python/tools/magnet/example.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Sep 30 17:58:20 2020
+
+@author: Bharat
+"""
+#File containing all the user defined MagNet functions and the pywin32 library needed for VBS
+import MagnetFunc  
+
+#Launch MagNet application and make window visible
+MN = MagnetFunc.launch()
+
+#Get Handles to MAGNET Scripting Interfaces
+[Doc, View, Circuit, MNConsts] = MagnetFunc.init(MN)
+
+#set Default length unit as millimeters
+Doc.setDefaultLengthUnit("millimeters", True)
+
+#draw circles with x,y as the coordinates of the centre, r as the radius
+MagnetFunc.drawCircle(View, 0, 0, 20)
+MagnetFunc.drawCircle(View, 0, 0, 30)
+MagnetFunc.drawCircle(View, 0, 0, 50)
+
+#select section 
+MagnetFunc.selectSection(View, MNConsts,-1, 0)
+#assign parameters needed for extrusion
+section1 = "conductor"
+material = 'Copper: 100% IACS'
+sweepDist = 10
+#extrude selected section by the distance specified in sweepDist with material and section name as provided. 
+sweep1Status = MagnetFunc.makeComponentInALine(MN, MNConsts, sweepDist, section1, material)
+
+
+MagnetFunc.selectSection(View, MNConsts,-25, 0)
+section2 = "air"
+material = 'AIR'
+sweepDist = 10
+#extrude selected section by the distance specified in sweepDist with material and section name as provided
+sweep2Status = MagnetFunc.makeComponentInALine(MN, MNConsts, sweepDist, section2, material)
+
+MagnetFunc.selectSection(View, MNConsts,-35, 0,)
+section3 = "iron"
+material = 'Arnon 5'
+sweepDist = 10
+#extrude selected section by the distance specified in sweepDist with material and section name as provided
+sweep3Status = MagnetFunc.makeComponentInALine(MN, MNConsts, sweepDist, section3, material)
+
+#make a simple coil
+coil1 = MagnetFunc.makeSimpleCoil(Doc, 1, section1)
+
+#assign relevant parameters to excite the coil
+Idc = 10
+MagnetFunc.setParameter(Doc, coil1, "WaveFormType", "DC", MNConsts)
+MagnetFunc.setParameter(Doc, coil1, "Current", Idc, MNConsts)
+
+'''
+sin_offset = 0
+sin_mag = 10
+ArrayValues = [sin_offset, sin_mag]
+MagnetFunc.setParameter(Doc,  coil1, "WaveFormType", "SIN", MNConsts)
+MagnetFunc.setParameter(Doc,  coil1, "WaveFormValues", ArrayValues, MNConsts)
+'''
+
+#make a motion component
+motion = MagnetFunc.makeMotionComponent(Doc,['iron'])
+
+#assign relevant parameters for the motion component
+positionAtStartup = 0
+speedAtStartup = 0
+timeArray = 0
+speedArray = 1000
+timespeed = [timeArray, speedArray]
+direction = [0,0,-1]
+#set parameters for the motion component
+MagnetFunc.setParameter(Doc, motion, 'MotionSourceType','VelocityDriven', MNConsts)
+MagnetFunc.setParameter(Doc, motion, 'MotionType','Rotary', MNConsts)
+MagnetFunc.setParameter(Doc, motion, 'PositionAtStartup',positionAtStartup, MNConsts)
+MagnetFunc.setParameter(Doc, motion, 'SpeedAtStartup',speedAtStartup, MNConsts)
+MagnetFunc.setParameter(Doc, motion, 'SpeedVsTime', timespeed, MNConsts)
+MagnetFunc.setParameter(Doc, motion, 'MotionDirection', direction, MNConsts)
+
+

--- a/python/tools/magnet/example.py
+++ b/python/tools/magnet/example.py
@@ -24,26 +24,27 @@ MagnetFunc.drawCircle(View, 0, 0, 50)
 #select section 
 MagnetFunc.selectSection(View, MNConsts,-1, 0)
 #assign parameters needed for extrusion
-section1 = "conductor"
+section1 = ["conductor"]
 material = 'Copper: 100% IACS'
 sweepDist = 10
 #extrude selected section by the distance specified in sweepDist with material and section name as provided. 
-sweep1Status = MagnetFunc.makeComponentInALine(MN, MNConsts, sweepDist, section1, material)
-
+sweep1Status = MagnetFunc.makeComponentInALine(View, MNConsts, sweepDist, section1, material)
 
 MagnetFunc.selectSection(View, MNConsts,-25, 0)
-section2 = "air"
+section2 = ["air"]
 material = 'AIR'
 sweepDist = 10
 #extrude selected section by the distance specified in sweepDist with material and section name as provided
-sweep2Status = MagnetFunc.makeComponentInALine(MN, MNConsts, sweepDist, section2, material)
+sweep2Status = MagnetFunc.makeComponentInALine(View, MNConsts, sweepDist, section2, material)
 
 MagnetFunc.selectSection(View, MNConsts,-35, 0,)
-section3 = "iron"
+section3 = ["iron"]
 material = 'Arnon 5'
 sweepDist = 10
 #extrude selected section by the distance specified in sweepDist with material and section name as provided
-sweep3Status = MagnetFunc.makeComponentInALine(MN, MNConsts, sweepDist, section3, material)
+sweep3Status = MagnetFunc.makeComponentInALine(View, MNConsts, sweepDist, section3, material)
+
+mat = MagnetFunc.getParameter(MN, section3[0], "Material")
 
 #make a simple coil
 coil1 = MagnetFunc.makeSimpleCoil(Doc, 1, section1)
@@ -53,6 +54,7 @@ Idc = 10
 MagnetFunc.setParameter(Doc, coil1, "WaveFormType", "DC", MNConsts)
 MagnetFunc.setParameter(Doc, coil1, "Current", Idc, MNConsts)
 
+curr = MagnetFunc.getParameter(MN, coil1, "Current")
 '''
 sin_offset = 0
 sin_mag = 10
@@ -78,5 +80,6 @@ MagnetFunc.setParameter(Doc, motion, 'PositionAtStartup',positionAtStartup, MNCo
 MagnetFunc.setParameter(Doc, motion, 'SpeedAtStartup',speedAtStartup, MNConsts)
 MagnetFunc.setParameter(Doc, motion, 'SpeedVsTime', timespeed, MNConsts)
 MagnetFunc.setParameter(Doc, motion, 'MotionDirection', direction, MNConsts)
+
 
 


### PR DESCRIPTION
# Description

This PR is to merge the python implementation of certain MagNet support functions already implemented in Matlab. 

# Supported Functions

## `getParameter`
This function allows the user to get the value and the type of a parameter of a MAGNET object. The syntax is `getParameter(MN, path, parameter)` , where `MN` is the MAGNET object,  `path` is the path of the object who's parameter the user wants to read,  `parameter` is the parameter which is to be read.
## `setParameter` 
This function allows the user set the parameter of a MAGNET object with the value that the user inputs. It does not return any value. The syntax is `setParameter(Doc, opath, param, value, MNConsts)`, where `Doc` is the MAGNET Doc object, `opath` is the path of the object who's parameter is to be modified, `param` is the parameter which is to be modified, `value` is the value with which the parameter is to be updated and `MNConsts` is the MAGNET Constants object.
## `makeComponentInALine`
This function allows the user to extrude a selected section, assign it a name and a material. The syntax is `makeComponentInALine(MN, MNConsts, sweepDist, sectionName, material)`, where `MN` is the MAGNET object, `MNConsts` is the MAGNET Constants object, `sweepDist` is the height to which the user wishes to extrude the section, `sectionName` is the name the user wishes to assign to the components and `material` is the material the user wishes to assign the component. The function returns a value of 0 if the extrusion was successful and 1 otherwise.
## `makeMotionComponent`
This function allows the user to set components as moving in MAGNET . The syntax is `makeMotionComponent(Doc,ArrayOfValues)`, where Doc is the MAGNET Doc object, `ArrayOfValues` is the list of components which are to be set in motion. The function returns the path of the created motion object.
##`makeSimpleCoil`
This function allows the user to make a simple coil in MAGNET . The syntax is `makeSimpleCoil(Doc, ProblemID, ArrayOfValues)`, where `Doc` is the MAGNET Doc object, `ProblemID` is the ProblemID assigned to the coil, `ArrayOfValues` is the list of components which are to be made into a coil. The function returns the path of the created coil object.

# Problems Encountered 

- In order for Python to send commands to MAGNET , we need to import the pywin32 to call ActiveX compliant programs as COM automation servers. pywin32 module comes installed when you install Anaconda3, however for Python to Import the module, the path of the module has to be defined in the system`Environment variables` for Windows (or the file we create has to be in the same directory as that of the file we are importing). 
[This link goes through the steps of adding the PYTHONPATH for different platforms](https://bic-berkeley.github.io/psych-214-fall-2016/using_pythonpath.html)
 - Return procedure for MAGNET differs for different functions as far as Python is concerned. For some functions such as `makeSimpleCoil` it can be as simple as `coil=Doc.makeSimpleCoil(ProblemID, ArrayOfValues)`, for others we need to put in more effort. For the `getParameter` for example, the return value can be extracted from MAGNET by employing the below code:
```python
    MN.processCommand("REDIM strArray(0)")
    MN.processCommand("DIM pType")
    MN.processCommand("pType = getDocument.getParameter(\"{}\", \"{}\", strArray)".format(path,parameter))
    MN.processCommand('Call setVariant(0, strArray,"PYTHON")')    
    param = MN.getVariant(0,"PYTHON")
    MN.processCommand('Call setVariant(0, pType,"PYTHON")')    
    param_type = MN.getVariant(0,"PYTHON")
    return param, param_type
```
The rule of thumb for knowing when to employ which syntax is that if a MAGNET specific API has an output argument then you need to use processCommand( ) and send the actual VBS command using python. The arguments of a MAGNET API can be obtained from MAGNET's Help Topics.
# Related Issues

Closes #118, #111 
