### PR TITLE
Change the signature of abstract methods

### DIFF
--- a/tools/DrawerBase.m
+++ b/tools/DrawerBase.m
@@ -13,8 +13,8 @@ classdef DrawerBase < handle
     end
    
     methods(Abstract = true)
-        new = drawLine(obj)
-        new = drawArc(obj)
+        new = drawLine(obj, startx, endx)
+        new = drawArc(obj, centerxy, startxy, endxy)
         new = select(obj)
     end
     

--- a/tools/DrawerBase.m
+++ b/tools/DrawerBase.m
@@ -13,7 +13,7 @@ classdef DrawerBase < handle
     end
    
     methods(Abstract = true)
-        new = drawLine(obj, startx, endx)
+        new = drawLine(obj, startxy, endxy)
         new = drawArc(obj, centerxy, startxy, endxy)
         new = select(obj)
     end


### PR DESCRIPTION
The signature of abstract methods in `DrawerBase` is updated to match the signature in `Magnet.m`

closes #152