### PR TITLE
Update MagNet tool to handle dimension and to revise application/file handling

### DIFF
--- a/python/emach/tools/magnet/magnet.py
+++ b/python/emach/tools/magnet/magnet.py
@@ -22,6 +22,9 @@ class MagNet(abc.ToolBase, abc.DrawerBase, abc.MakerExtrudeBase, abc.MakerRevolv
         self.view = None
         self.sol = None
         self.consts = None
+        self.default_length = None
+        self.default_angle = None
+        self.filename = None
         
     def __del__(self):
         self.mn.close(False)
@@ -35,6 +38,7 @@ class MagNet(abc.ToolBase, abc.DrawerBase, abc.MakerExtrudeBase, abc.MakerRevolv
         
         if filename is str:
             self.doc = self.mn.openDocument(filename)
+            self.filename = filename
         else:
             self.doc = self.mn.newDocument()
         self.view = self.doc.getView()
@@ -46,9 +50,15 @@ class MagNet(abc.ToolBase, abc.DrawerBase, abc.MakerExtrudeBase, abc.MakerRevolv
     def close(self):
         self.doc.close(False)
         
-    def save(self, path, filename):
-        filepath = path+filename
-        self.doc.save(filepath)
+    def save_as(self, filename):
+        self.filename = filename
+        self.save()
+        
+    def save(self):
+        if self.filename is str:
+            self.doc.save(self.filename)
+        else:
+            raise AttributeError('Unable to save file. Use the save_as() function')
         
     def draw_line(self, startxy, endxy):
         """

--- a/python/emach/tools/magnet/magnet.py
+++ b/python/emach/tools/magnet/magnet.py
@@ -15,22 +15,25 @@ class MagNet(abc.ToolBase, abc.DrawerBase, abc.MakerExtrudeBase, abc.MakerRevolv
     """ A class to handle MagNet applications
     """
 
-    def __init__(self):
-        self.disp_ex = None
-        self.doc = None
+    def __init__(self, visible = False):
+        self.disp_ex = DispatchEx("MagNet.Application")
+        self.disp_ex.visible = visible 
         self.view = None
         self.sol = None
         self.consts = None
         self.default_length = 'DimMillimeter'
         self.default_angle = 'DimDegree'
+    
+    def __del__(self, filepath = None):
+        if filepath is str:
+            self.doc.save(filepath)
+        self.disp_ex.close(False)
 
-    def open(self, filename=None, visible=False):
+    def open(self, filename=None):
         """ opens a new MAGNET session and assigns variables neccessary for further
         operations
         """
 
-        self.disp_ex = DispatchEx("MagNet.Application")  # Opens a new MAGNET session
-        self.disp_ex.visible = visible  # Makes MAGNET window visible
         if filename is str:
             self.doc = self.disp_ex.openDocument(filename)
         else:
@@ -39,8 +42,10 @@ class MagNet(abc.ToolBase, abc.DrawerBase, abc.MakerExtrudeBase, abc.MakerRevolv
         self.sol = self.doc.getSolution()
         self.consts = self.disp_ex.getConstants()  # Get MAGNET Constants
 
-    def close(self):
-        pass
+    def close(self, filepath = None):
+        if filepath is str:
+            self.doc.save(filepath)
+        self.view.close(False)
 
     def draw_line(self, startxy, endxy):
         """

--- a/python/emach/tools/magnet/magnet.py
+++ b/python/emach/tools/magnet/magnet.py
@@ -95,14 +95,14 @@ class MagNet(abc.ToolBase, abc.DrawerBase, abc.MakerExtrudeBase, abc.MakerRevolv
         return TokenDraw(line,0)
 
 
-    def draw_arc(self, centrexy, startxy, endxy):
+    def draw_arc(self, centerxy, startxy, endxy):
         """
         Draws an arc in MAGNET
 
         Parameters
         ----------
-        centrexy : integer list of len 2
-            the centre coordinate of the arc.
+        centerxy : integer list of len 2
+            the center coordinate of the arc.
         startxy : integer list of len 2
             the starting coordinate of the arc
         endxy : Tinteger list of len 2
@@ -113,8 +113,8 @@ class MagNet(abc.ToolBase, abc.DrawerBase, abc.MakerExtrudeBase, abc.MakerRevolv
         ret : TokenDraw object
 
         """
-        center_x = eval(self.default_length)(centrexy[0])
-        center_y = eval(self.default_length)(centrexy[1])
+        center_x = eval(self.default_length)(centerxy[0])
+        center_y = eval(self.default_length)(centerxy[1])
         start_x = eval(self.default_length)(startxy[0])
         start_y = eval(self.default_length)(startxy[1])
         end_x = eval(self.default_length)(endxy[0])

--- a/python/emach/tools/tool_abc/toolabc.py
+++ b/python/emach/tools/tool_abc/toolabc.py
@@ -15,9 +15,13 @@ class ToolBase(ABC):
     def open(self, filename: str, length_unit: str, angle_unit: str) -> any: pass
     
     @abstractmethod 
-    def save(self, path: str, filename: str):
+    def save(self):
         pass
         
+    @abstractmethod 
+    def save_as(self, filename: str):
+        pass
+    
     @abstractmethod
     def close(self): pass
 

--- a/python/emach/tools/tool_abc/toolabc.py
+++ b/python/emach/tools/tool_abc/toolabc.py
@@ -12,8 +12,12 @@ from typing import Tuple
 # define abstract base class for ToolBase
 class ToolBase(ABC):
     @abstractmethod
-    def open(self, filename: str, visible: bool) -> any: pass
+    def open(self, filename: str, length_unit: str, angle_unit: str) -> any: pass
     
+    @abstractmethod 
+    def save(self, path: str, filename: str):
+        pass
+        
     @abstractmethod
     def close(self): pass
 
@@ -32,7 +36,7 @@ class DrawerBase(ABC):
 
 class MakerBase(ABC):
     @abstractmethod
-    def prepare_section(self, inner_coord: 'Location2D') -> any: pass
+    def prepare_section(self, cs_token: 'CrossSectToken') -> any: pass
 
 # define abstract base class for MakerExtrudeBase
 class MakerExtrudeBase(MakerBase):

--- a/python/examples/example_dimension_unit_test.py
+++ b/python/examples/example_dimension_unit_test.py
@@ -1,8 +1,5 @@
-# add the directory immediately above this file's directory to path for module import
-import sys
-sys.path.append("..")  
 
-from model_obj import DimMillimeter, DimInch, DimDegree, DimRadian
+from emach.model_obj import DimMillimeter, DimInch, DimDegree, DimRadian
 
 inchObject = DimInch(1)
 milObject = DimMillimeter(25.4)

--- a/python/examples/example_dimension_unit_test.py
+++ b/python/examples/example_dimension_unit_test.py
@@ -1,4 +1,7 @@
 
+import sys
+sys.path.append('..')
+                
 from emach.model_obj import DimMillimeter, DimInch, DimDegree, DimRadian
 
 inchObject = DimInch(1)

--- a/python/examples/example_magnet_apis.py
+++ b/python/examples/example_magnet_apis.py
@@ -4,11 +4,8 @@ Created on Fri Oct 23 02:35:48 2020
 
 @author: Bharat
 """
-# add the directory immediately above this file's directory to path for module import
-import sys
-sys.path.append("..")  
 
-import tools.magnet as mn
+import emach.tools.magnet as mn
 
 # create an instance of the MagNet class
 MN = mn.MagNet()

--- a/python/examples/example_magnet_apis.py
+++ b/python/examples/example_magnet_apis.py
@@ -1,10 +1,6 @@
-# -*- coding: utf-8 -*-
-"""
-Created on Fri Oct 23 02:35:48 2020
 
-@author: Bharat
-"""
-
+import sys
+sys.path.append("..")  
 import emach.tools.magnet as mn
 
 # create an instance of the MagNet class

--- a/python/examples/example_magnet_apis.py
+++ b/python/examples/example_magnet_apis.py
@@ -8,8 +8,8 @@ Created on Fri Oct 23 02:35:48 2020
 import emach.tools.magnet as mn
 
 # create an instance of the MagNet class
-MN = mn.MagNet()
-MN.open(visible=True)
+MN = mn.MagNet(visible=True)
+MN.open()
 
 
 # draw circles with x,y as the coordinates of the centre, r as the radius
@@ -87,3 +87,5 @@ mn.document.set_parameter(MN.doc, motion, "PositionAtStartup",
 mn.document.set_parameter(MN.doc, motion, "SpeedAtStartup", speed_at_startup, MN.consts)
 mn.document.set_parameter(MN.doc, motion, "MotionDirection", direction, MN.consts)
 mn.document.set_parameter(MN.doc, motion, "SpeedVsTime", time_speed, MN.consts)
+
+del MN

--- a/python/examples/example_magnet_apis.py
+++ b/python/examples/example_magnet_apis.py
@@ -4,8 +4,6 @@ Created on Fri Oct 23 02:35:48 2020
 
 @author: Bharat
 """
-import sys
-sys.path.append('..')
 
 import emach.tools.magnet as mn
 
@@ -49,7 +47,7 @@ sweep3Status = mn.document.view.make_component_in_a_line(
     MN.view, MN.consts, sweep_dist, section3, material
 )
 
-mat = mn.document.get_parameter(MN.disp_ex,
+mat = mn.document.get_parameter(MN.mn,
                                          section3[0], "Material")
 
 # make a simple coil
@@ -60,7 +58,7 @@ i_dc = 10
 mn.document.set_parameter(MN.doc, coil1, "WaveFormType", "DC", MN.consts)
 mn.document.set_parameter(MN.doc, coil1, "Current", i_dc, MN.consts)
 
-curr = mn.document.get_parameter(MN.disp_ex, coil1, "Current")
+curr = mn.document.get_parameter(MN.mn, coil1, "Current")
 
 """
 sin_offset = 0

--- a/python/examples/example_magnet_apis.py
+++ b/python/examples/example_magnet_apis.py
@@ -4,6 +4,8 @@ Created on Fri Oct 23 02:35:48 2020
 
 @author: Bharat
 """
+import sys
+sys.path.append('..')
 
 import emach.tools.magnet as mn
 

--- a/python/examples/example_magnet_base_methods.py
+++ b/python/examples/example_magnet_base_methods.py
@@ -4,6 +4,8 @@ Created on Fri Oct 16 16:54:12 2020
 
 @author: Bharat
 """
+import sys
+sys.path.append('..')
 
 import emach.tools.magnet as mn
 # create an instance of the MagNet class

--- a/python/examples/example_magnet_base_methods.py
+++ b/python/examples/example_magnet_base_methods.py
@@ -4,8 +4,6 @@ Created on Fri Oct 16 16:54:12 2020
 
 @author: Bharat
 """
-import sys
-sys.path.append('..')
 
 import emach.tools.magnet as mn
 # create an instance of the MagNet class
@@ -16,7 +14,7 @@ MN.open()
 #l2 = MN.drawLine('e1','2y')
 
 #set default dimension to millimeter
-MN.set_default_length('millimeters', False)
+MN.set_default_length('DimMillimeter', False)
 
 # set coordinates to draw line and arc
 center = [0, 0]
@@ -28,8 +26,14 @@ l1 = MN.draw_line(start, end)
 arc1 = MN.draw_arc(center, start, end)
 
 # select section which contains the coordinates provided
+# create dummy class to replicate CSToken
+class DummyToken:
+    pass
+dt = DummyToken()
 inner_coord = [0, -5]
-MN.prepare_section(inner_coord)
+
+setattr(dt, 'inner_coord', inner_coord)
+MN.prepare_section(dt)
 
 # set properties of the material to be extruded
 name1 = ["conductor"]

--- a/python/examples/example_magnet_base_methods.py
+++ b/python/examples/example_magnet_base_methods.py
@@ -1,10 +1,6 @@
-# -*- coding: utf-8 -*-
-"""
-Created on Fri Oct 16 16:54:12 2020
 
-@author: Bharat
-"""
-
+import sys
+sys.path.append("..")  
 import emach.tools.magnet as mn
 # create an instance of the MagNet class
 MN = mn.MagNet(visible=True)

--- a/python/examples/example_magnet_base_methods.py
+++ b/python/examples/example_magnet_base_methods.py
@@ -7,8 +7,8 @@ Created on Fri Oct 16 16:54:12 2020
 
 import emach.tools.magnet as mn
 # create an instance of the MagNet class
-MN = mn.MagNet()
-MN.open(visible=True)
+MN = mn.MagNet(visible=True)
+MN.open()
 
 # passing incorrect argument to drawLine to show error handling
 #l2 = MN.drawLine('e1','2y')
@@ -44,3 +44,4 @@ angle1 = 90
 
 #revlove section, comment out extrude if you want to see revolve in action
 # revolve1 = MN.revolve(name1, material1, center1, axis1, angle1)
+del MN

--- a/python/examples/example_magnet_base_methods.py
+++ b/python/examples/example_magnet_base_methods.py
@@ -4,17 +4,17 @@ Created on Fri Oct 16 16:54:12 2020
 
 @author: Bharat
 """
-# add the directory immediately above this file's directory to path for module import
-import sys
-sys.path.append("..")
 
-import tools.magnet as mn
+import emach.tools.magnet as mn
 # create an instance of the MagNet class
 MN = mn.MagNet()
 MN.open(visible=True)
 
 # passing incorrect argument to drawLine to show error handling
 #l2 = MN.drawLine('e1','2y')
+
+#set default dimension to millimeter
+MN.set_default_length('millimeters', False)
 
 # set coordinates to draw line and arc
 center = [0, 0]
@@ -35,7 +35,7 @@ material1 = "Copper: 100% IACS"
 depth1 = 10
 
 # extrude section, comment out revolve if you want to see extrude in action
-# extrude1 = MN.extrude(name1,material1,depth1)
+extrude1 = MN.extrude(name1,material1,depth1)
 
 # set properties of the material to be revolved
 center1 = [0, 0]
@@ -43,4 +43,4 @@ axis1 = [1, 0]
 angle1 = 90
 
 #revlove section, comment out extrude if you want to see revolve in action
-revolve1 = MN.revolve(name1, material1, center1, axis1, angle1)
+# revolve1 = MN.revolve(name1, material1, center1, axis1, angle1)


### PR DESCRIPTION
# Description
This PR implements the issue raised in #153 and #172 . The `MagNet` tool now converts all `dimensions` to the default setting before passing the values on to the FEA software. The tool also opens the application upon object `construction` and closes application upon calling the `destructor`. 

# Problems Encountered
In order for the `MagNet` tool to access the dimensions classes such as `DimMillimeter` and `DimInch`, importing those classes from the corresponding module is necessary. `Python`, however does not allow a user to import modules that are at or above the directory where the execution file resides. Therefore, it became necessary to move the example folder to one level higher in order to get the code working.
