### PR TITLE
Update MagNet MATLAB tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ octave-workspace
 *.eps
 *.log
 
+*.mn

--- a/examples/exampleAFPM2D/ConstructAFPM2DExample.m
+++ b/examples/exampleAFPM2D/ConstructAFPM2DExample.m
@@ -1,8 +1,9 @@
 function [toolMn,coil_A,coil_B,coil_C] = ConstructAFPM2DExample(t_y, t_m, g, h, w_m, w_c, w, p, Q, linspeed)
 maxEleRemesh = 2; % max element size for remesh region
 toolMn = MagNet();
-toolMn.open(0,0,true); % open MagNet
-toolMn.setDefaultLengthUnit('millimeters', false); % set default length units
+toolMn.open();
+toolMn.setVisibility(1);
+toolMn.setDefaultLengthUnit('DimMillimeter', false); % set default length units
 
 %% Draw geometry
 

--- a/examples/exampleAFPM2D/TransientSolveAFPM2DExample.m
+++ b/examples/exampleAFPM2D/TransientSolveAFPM2DExample.m
@@ -81,4 +81,5 @@ close all
     save('AFPMSolution.mat','solutiondata');
 
 %% Close MagNet
-invoke(toolMn.mn, 'processcommand','CALL close(False)');
+toolMn.close();
+delete(toolMn);

--- a/examples/exampleBreadloaf.m
+++ b/examples/exampleBreadloaf.m
@@ -90,8 +90,9 @@ comp3 = Component( ...
 
 if (DRAW_MAGNET)
     toolMn = MagNet();
-    toolMn.open(0,0,true);
-    toolMn.setDefaultLengthUnit('millimeters', false);
+    toolMn.open();
+    toolMn.setVisibility(1);
+    toolMn.setDefaultLengthUnit('DimMillimeter', false);
 
     comp1.make(toolMn, toolMn);
     comp2.make(toolMn, toolMn);

--- a/examples/exampleHollowCylinder.m
+++ b/examples/exampleHollowCylinder.m
@@ -36,8 +36,9 @@ comp1 = Component( ...
 
 if (DRAW_MAGNET)
     toolMn = MagNet();
-    toolMn.open(0,0,true);
-    toolMn.setDefaultLengthUnit('millimeters', false);
+    toolMn.open();
+    toolMn.setVisibility(1);
+    toolMn.setDefaultLengthUnit('DimMillimeter', false);
 
     comp1.make(toolMn, toolMn);
 

--- a/examples/exampleHollowRect.m
+++ b/examples/exampleHollowRect.m
@@ -39,9 +39,9 @@ comp1 = Component( ...
 
 if (DRAW_MAGNET)
     toolMn = MagNet();
-    toolMn.open(0,0,true);
-    toolMn.setDefaultLengthUnit('millimeters', false);
-
+    toolMn.open();
+    toolMn.setVisibility(1);
+    toolMn.setDefaultLengthUnit('DimMillimeter', false);
     comp1.make(toolMn,toolMn);
 
     toolMn.viewAll();

--- a/examples/exampleLinearMotor.m
+++ b/examples/exampleLinearMotor.m
@@ -229,9 +229,10 @@ coil2Comp = Component( ...
 
 if (DRAW_MAGNET)
     toolMn = MagNet();
-    toolMn.open(0,0,true);
-    toolMn.setDefaultLengthUnit('millimeters', false);
-
+    toolMn.open();
+    toolMn.setVisibility(1);
+    toolMn.setDefaultLengthUnit('DimMillimeter', false);
+    
     statorIronComp.make(toolMn, toolMn);
     moverIronComp.make(toolMn, toolMn);
     magnet1Comp.make(toolMn, toolMn);

--- a/examples/exampleNotchedRectangle.m
+++ b/examples/exampleNotchedRectangle.m
@@ -38,9 +38,9 @@ comp1 = Component( ...
 
 if (DRAW_MAGNET)
     toolMn = MagNet();
-    toolMn.open(0,0,true);
-    toolMn.setDefaultLengthUnit('millimeters', false);
-
+    toolMn.open();
+    toolMn.setVisibility(1);
+    toolMn.setDefaultLengthUnit('DimMillimeter', false);
     comp1.make(toolMn, toolMn);
 
     toolMn.viewAll();

--- a/examples/exampleNotchedRotor.m
+++ b/examples/exampleNotchedRotor.m
@@ -42,8 +42,9 @@ comp1 = Component( ...
 
 if (DRAW_MAGNET)
     toolMn = MagNet();
-    toolMn.open(0,0,true);
-    toolMn.setDefaultLengthUnit('millimeters', false);
+    toolMn.open();
+    toolMn.setVisibility(1);
+    toolMn.setDefaultLengthUnit('DimMillimeter', false);
 
     comp1.make(toolMn,toolMn);
 

--- a/examples/exampleParallelogram.m
+++ b/examples/exampleParallelogram.m
@@ -42,9 +42,10 @@ if (DRAW_MAGNET)
     toolMn = MagNet();
     toolMn.setVisibility(1);
     toolMn.open();
+    toolMn.saveas(fileName);
     comp1.make(toolMn,toolMn);
     toolMn.viewAll();
-    toolMn.save(fileName);
+    toolMn.save();
     toolMn.close();
     if isvalid(toolMn)
         fprintf('Pre-destructor: toolMn exists\n');

--- a/examples/exampleParallelogram.m
+++ b/examples/exampleParallelogram.m
@@ -39,6 +39,7 @@ fileName = 'test1.mn';
 
 if (DRAW_MAGNET)
     toolMn = MagNet();
+    toolMn.setVisibility(1);
     toolMn.open(0);
     comp1.make(toolMn,toolMn);
     toolMn.viewAll();

--- a/examples/exampleParallelogram.m
+++ b/examples/exampleParallelogram.m
@@ -42,7 +42,7 @@ if (DRAW_MAGNET)
     toolMn = MagNet();
     toolMn.setVisibility(1);
     toolMn.open();
-    toolMn.saveas(fileName);
+    toolMn.saveAs(fileName);
     comp1.make(toolMn,toolMn);
     toolMn.viewAll();
     toolMn.save();

--- a/examples/exampleParallelogram.m
+++ b/examples/exampleParallelogram.m
@@ -40,7 +40,7 @@ fileName = 'test1.mn';
 if (DRAW_MAGNET)
     toolMn = MagNet();
     toolMn.setVisibility(1);
-    toolMn.open(0);
+    toolMn.open();
     comp1.make(toolMn,toolMn);
     toolMn.viewAll();
     toolMn.save(path, fileName);

--- a/examples/exampleParallelogram.m
+++ b/examples/exampleParallelogram.m
@@ -35,7 +35,8 @@ comp1 = Component( ...
 
 %% Draw via MagNet
 path = pwd;
-fileName = 'test1.mn';
+modelName = 'test1.mn';
+fileName = fullfile(path, modelName);
 
 if (DRAW_MAGNET)
     toolMn = MagNet();
@@ -43,7 +44,7 @@ if (DRAW_MAGNET)
     toolMn.open();
     comp1.make(toolMn,toolMn);
     toolMn.viewAll();
-    toolMn.save(path, fileName);
+    toolMn.save(fileName);
     toolMn.close();
     if isvalid(toolMn)
         fprintf('Pre-destructor: toolMn exists\n');

--- a/examples/exampleParallelogram.m
+++ b/examples/exampleParallelogram.m
@@ -35,17 +35,28 @@ comp1 = Component( ...
 
 %% Draw via MagNet
 path = pwd;
-fileName = 'test.mn';
+fileName = 'test1.mn';
 
 if (DRAW_MAGNET)
     toolMn = MagNet();
-    toolMn.create();
     toolMn.open(0);
     comp1.make(toolMn,toolMn);
     toolMn.viewAll();
     toolMn.save(path, fileName);
     toolMn.close();
+    if isvalid(toolMn)
+        fprintf('Pre-destructor: toolMn exists\n');
+    else
+        fprintf('Pre-destructor: toolMn does not exist\n');
+    end
+    
     delete(toolMn);
+    
+    if isvalid(toolMn)
+        fprintf('Failure: toolMn exists\n');
+    else
+        fprintf('Success: toolMn is destroyed\n');
+    end
 end
 
 %% Draw via TikZ

--- a/examples/exampleParallelogram.m
+++ b/examples/exampleParallelogram.m
@@ -34,15 +34,18 @@ comp1 = Component( ...
         );
 
 %% Draw via MagNet
+path = pwd;
+fileName = 'test.mn';
 
 if (DRAW_MAGNET)
     toolMn = MagNet();
-    toolMn.open(0,0,true);
-    toolMn.setDefaultLengthUnit('millimeters', false);
-
+    toolMn.create();
+    toolMn.open(0);
     comp1.make(toolMn,toolMn);
-
     toolMn.viewAll();
+    toolMn.save(path, fileName);
+    toolMn.close();
+    delete(toolMn);
 end
 
 %% Draw via TikZ

--- a/examples/exampleSolidRectangle.m
+++ b/examples/exampleSolidRectangle.m
@@ -35,9 +35,9 @@ comp1 = Component( ...
 
 if (DRAW_MAGNET)
     toolMn = MagNet();
-    toolMn.open(0,0,true);
-    toolMn.setDefaultLengthUnit('millimeters', false);
-
+    toolMn.open();
+    toolMn.setVisibility(1);
+    toolMn.setDefaultLengthUnit('DimMillimeter', false);
     comp1.make(toolMn,toolMn);
 
     toolMn.viewAll();

--- a/examples/innerRotorExample.m
+++ b/examples/innerRotorExample.m
@@ -141,8 +141,9 @@ comp1 = Component( ...
 
 if (DRAW_MAGNET)
     toolMn = MagNet();
-    toolMn.open(0,0,true);
-    toolMn.setDefaultLengthUnit('millimeters', false);
+    toolMn.open();
+    toolMn.setVisibility(1);
+    toolMn.setDefaultLengthUnit('DimMillimeter', false);
 
     comp1.make(toolMn, toolMn);
 

--- a/examples/main.m
+++ b/examples/main.m
@@ -48,8 +48,9 @@ comp1 = Component( ...
 
 if (DRAW_MAGNET)
     toolMn = MagNet();
-    toolMn.open(0,0,true);
-    toolMn.setDefaultLengthUnit('millimeters', false);
+    toolMn.open();
+    toolMn.setVisibility(1);
+    toolMn.setDefaultLengthUnit('DimMillimeter', false);
 
     comp1.make(toolMn, toolMn);
 

--- a/examples/makeSolidExample.m
+++ b/examples/makeSolidExample.m
@@ -37,8 +37,9 @@ comp1 = Component( ...
 
 if (DRAW_MAGNET)
     toolMn = MagNet();
-    toolMn.open(0,0,true);
-    toolMn.setDefaultLengthUnit('millimeters', false);
+    toolMn.open();
+    toolMn.setVisibility(1);
+    toolMn.setDefaultLengthUnit('DimMillimeter', false);
 
     comp1.make(toolMn, toolMn);
 

--- a/examples/outerRotorExample.m
+++ b/examples/outerRotorExample.m
@@ -42,8 +42,9 @@ comp1 = Component( ...
 
 if (DRAW_MAGNET)
     toolMn = MagNet();
-    toolMn.open(0,0,true);
-    toolMn.setDefaultLengthUnit('millimeters', false);
+    toolMn.open();
+    toolMn.setVisibility(1);
+    toolMn.setDefaultLengthUnit('DimMillimeter', false);
 
     comp1.make(toolMn, toolMn);
 

--- a/examples/outerRotorStatorExample.m
+++ b/examples/outerRotorStatorExample.m
@@ -46,8 +46,9 @@ comp1 = Component( ...
 
 if (DRAW_MAGNET)
     toolMn = MagNet();
-    toolMn.open(0,0,true);
-    toolMn.setDefaultLengthUnit('millimeters', false);
+    toolMn.open();
+    toolMn.setVisibility(1);
+    toolMn.setDefaultLengthUnit('DimMillimeter', false);
 
     comp1.make(toolMn, toolMn);
 

--- a/examples/xfemmExampleArc.m
+++ b/examples/xfemmExampleArc.m
@@ -58,8 +58,9 @@ comp2 = Component( ...
 
 if (DRAW_MAGNET)
     toolMn = MagNet();
-    toolMn.open(0,0,true);
-    toolMn.setDefaultLengthUnit('millimeters', false);
+    toolMn.open();
+    toolMn.setVisibility(1);
+    toolMn.setDefaultLengthUnit('DimMillimeter', false);
 
     comp1.make(toolMn, toolMn);
     comp2.make(toolMn, toolMn);

--- a/examples/xfemmExampleNotchedRectangle.m
+++ b/examples/xfemmExampleNotchedRectangle.m
@@ -39,8 +39,9 @@ comp1 = Component( ...
 
 if (DRAW_MAGNET)
     toolMn = MagNet();
-    toolMn.open(0,0,true);
-    toolMn.setDefaultLengthUnit('millimeters', false);
+    toolMn.open();
+    toolMn.setVisibility(1);
+    toolMn.setDefaultLengthUnit('DimMillimeter', false);
 
     comp1.make(toolMn, toolMn);
 

--- a/tools/ToolBase.m
+++ b/tools/ToolBase.m
@@ -13,7 +13,7 @@ classdef ToolBase < handle
     end
     
     methods(Abstract = true)
-        open(obj, fileName);
+        open(obj, path, fileName);
         save(obj, path, fileName)
         close(obj);
     end

--- a/tools/ToolBase.m
+++ b/tools/ToolBase.m
@@ -14,7 +14,8 @@ classdef ToolBase < handle
     
     methods(Abstract = true)
         open(obj, fileName);
-        save(obj, fileName);
+        saveAs(obj, fileName);
+        save(obj);
         close(obj);
     end
     

--- a/tools/ToolBase.m
+++ b/tools/ToolBase.m
@@ -13,8 +13,9 @@ classdef ToolBase < handle
     end
     
     methods(Abstract = true)
-        open(obj);
-        close(obj);
+        open(obj, fileName);
+        save(obj, path, fileName)
+        close(obj, fileName);
     end
     
      methods(Access = protected)

--- a/tools/ToolBase.m
+++ b/tools/ToolBase.m
@@ -15,7 +15,7 @@ classdef ToolBase < handle
     methods(Abstract = true)
         open(obj, fileName);
         save(obj, path, fileName)
-        close(obj, fileName);
+        close(obj);
     end
     
      methods(Access = protected)

--- a/tools/ToolBase.m
+++ b/tools/ToolBase.m
@@ -13,8 +13,8 @@ classdef ToolBase < handle
     end
     
     methods(Abstract = true)
-        open(obj, path, fileName);
-        save(obj, path, fileName)
+        open(obj, fileName);
+        save(obj, fileName);
         close(obj);
     end
     

--- a/tools/ToolBase.m
+++ b/tools/ToolBase.m
@@ -13,10 +13,10 @@ classdef ToolBase < handle
     end
     
     methods(Abstract = true)
-        open(obj, fileName);
-        saveAs(obj, fileName);
-        save(obj);
-        close(obj);
+        open(obj, fileName); % Open a file
+        save(obj); % Save the current file
+        saveAs(obj, fileName); % Save the current file with the specified name at the specified location
+        close(obj); % Close the file
     end
     
      methods(Access = protected)

--- a/tools/magnet/MagNet.m
+++ b/tools/magnet/MagNet.m
@@ -8,35 +8,21 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
     properties (GetAccess = 'public', SetAccess = 'private')
         mn;  % MagNet activexserver object
         doc; % Document object
-        view; %View object
+        view; % View object
         consts; %Program constants
         defaultLength = 'DimMillimeter';
         defaultAngle  = 'DimDegree';
+        visible = 1;% Default visibility
     end
     
     methods
         function obj = MagNet(varargin)
             obj = obj.createProps(nargin,varargin);            
-            obj.validateProps();            
+            obj.validateProps();        
+            obj.mn = actxserver('MagNet.Application');
+            set(obj.mn, 'Visible', obj.visible);
         end
-        
-        
-        function obj = create(obj, visible)
-            %CREATE Create a new MagNet instance 
-            %   create() creates a new instance of MagNet.
-            %
-            %   create(visible) sets the visibility of the created instance.
-            %   visible = 1 or 'true' for MagNet instance to be visible.
-            %   visible = 0 or 'false' for MagNet instace to be invisible.
-           obj.mn = actxserver('MagNet.Application');
-           if nargin > 1 && (visible  == 1 || visible == 0 ||...
-                   visible == 'true' || visible == 'false')
-              set(obj.mn, 'Visible', visible);
-           else
-              set(obj.mn, 'Visible', 1);
-           end
-        end
-
+                
          function open(obj, fileName)
             %OPEN Open MagNet
             %   open() opens a new instance of MagNet with a new document.

--- a/tools/magnet/MagNet.m
+++ b/tools/magnet/MagNet.m
@@ -26,10 +26,16 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
          function open(obj, fileName)
             %OPEN Open MagNet
             %   open() opens a new instance of MagNet with a new document.
-            obj.doc = invoke(obj.mn, 'newDocument');          
-            obj.view = invoke(obj.doc, 'getview');
-            obj.consts = invoke(obj.mn, 'getConstants');
-            obj.setDefaultLengthUnit('millimeters', false);
+            %   open(fileName) opens an existing MagNet document. fileName
+            %   is a string that has the full filepath and the file name.
+            if isempty(fileName)
+                obj.doc = invoke(obj.mn, 'newDocument');
+            else
+                obj.doc = invoke(obj.mn, 'openDocument', fileName);
+            end
+                obj.view = invoke(obj.doc, 'getview');
+                obj.consts = invoke(obj.mn, 'getConstants');
+                obj.setDefaultLengthUnit('millimeters', false);
          end
         
          function save(obj, path, fileName)

--- a/tools/magnet/MagNet.m
+++ b/tools/magnet/MagNet.m
@@ -20,32 +20,28 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
             obj.validateProps();            
         end
         
-        function obj = open(obj, fileName, mn, visible)
-            %OPEN Open MagNet or a specific file.
+        
+        function obj = create(obj, visible)
+            %CREATE Create a new MagNet instance 
+            %   create() creates a new instance of MagNet.
+            %
+            %   create(visible) sets the visibility of the created instance.
+            %   visible = 1 or 'true' for MagNet instance to be visible.
+            %   visible = 0 or 'false' for MagNet instace to be invisible.
+           obj.mn = actxserver('MagNet.Application');
+           if nargin > 1 && (visible  == 1 || visible == 0 ||...
+                   visible == 'true' || visible == 'false')
+              set(obj.mn, 'Visible', visible);
+           else
+              set(obj.mn, 'Visible', 1);
+           end
+        end
+
+         function open(obj, fileName)
+            %OPEN Open MagNet
             %   open() opens a new instance of MagNet with a new document.
             %
             %   open('filename') opens the file in a new instance of MagNet.
-            %
-            %   open('filename', mn) opens the file in the mn MagNet instance
-            %
-            %   open('filename', mn, visible) opens the file in the mn MagNet
-            %        instance with customizable visibility (true for visible)
-            %
-            %   mn and fileName can be set to 0 to allow setting
-            %   the visibility of a new instance.
-
-            if nargin < 2
-                obj.mn = actxserver('MagNet.Application');
-            end
-            
-            if nargin > 2
-                if isnumeric(mn)
-                    obj.mn = actxserver('MagNet.Application');
-                end
-                
-                set(obj.mn, 'Visible', visible);
-            end
-
             if nargin > 0 && ~isnumeric(fileName)
                 obj.doc = invoke(obj.mn, 'openDocument', fileName);
             else

--- a/tools/magnet/MagNet.m
+++ b/tools/magnet/MagNet.m
@@ -13,7 +13,9 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
         defaultLength = 'DimMillimeter';
         defaultAngle  = 'DimDegree';
         visible = 0;% visibility
+        fileName; % Name of the MagNet document
     end
+
     
     methods
         function obj = MagNet(varargin)
@@ -32,18 +34,27 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
                 obj.doc = invoke(obj.mn, 'newDocument');
             else
                 obj.doc = invoke(obj.mn, 'openDocument', fileName);
+                obj.fileName = fileName;
             end
                 obj.view = invoke(obj.doc, 'getview');
                 obj.consts = invoke(obj.mn, 'getConstants');
                 obj.setDefaultLengthUnit(obj.defaultLength, false);
          end
         
-         function save(obj, fileName)
-            % SAVE Save the MagNet document.
+         function saveas(obj, fileName)
+            % SAVEAS Save the MagNet document.
             % fileName is a string that specifies the complete path to the file.
             invoke(obj.mn, 'processcommand',...
-                     sprintf('Call getDocument().save("%s")',fileName)); 
+                     sprintf('Call getDocument().save("%s")',fileName));
+            obj.fileName = fileName;
          end
+         
+         function save(obj)
+            % SAVE Save the MagNet document.
+            invoke(obj.mn, 'processcommand',...
+                     sprintf('Call getDocument().save("%s")',obj.fileName));
+         end
+         
          
         function close(obj)
            % CLOSE Closes the MagNet document

--- a/tools/magnet/MagNet.m
+++ b/tools/magnet/MagNet.m
@@ -12,7 +12,7 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
         consts; %Program constants
         defaultLength = 'DimMillimeter';
         defaultAngle  = 'DimDegree';
-        visible = 1;% Default visibility
+        defaultVisibility = 0;% Default visibility
     end
     
     methods
@@ -20,7 +20,7 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
             obj = obj.createProps(nargin,varargin);            
             obj.validateProps();        
             obj.mn = actxserver('MagNet.Application');
-            set(obj.mn, 'Visible', obj.visible);
+            set(obj.mn, 'Visible', obj.defaultVisibility);
         end
                 
          function open(obj, fileName)

--- a/tools/magnet/MagNet.m
+++ b/tools/magnet/MagNet.m
@@ -23,35 +23,26 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
             set(obj.mn, 'Visible', obj.visible);
         end
                 
-         function open(obj, varargin)
+         function open(obj, fileName)
             %OPEN Open MagNet
             %   open() opens a new instance of MagNet with a new document.
-            %   open('path', path, 'fileName', fileName) opens an existing MagNet document. 
-            %   path is a string that specifies the file path.
-            %   fileName is a string that specifies the name of the file.  
-            %   Both path and fileName are specified as a key-value pair.
-            p = inputParser;
-            p.addParameter('fileName','');
-            p.addParameter('path','');
-            p.parse(varargin{:});
-            fileName = p.Results.fileName;
-            path = p.Results.path;
-            filePath = fullfile(path, fileName);
-            if ~exist(fileName)||~exist(path)
+            %   open(fileName) opens an existing MagNet document. 
+            %   fileName is a string that specifies the complete path to the file.  
+            if ~exist('fileName', 'var')
                 obj.doc = invoke(obj.mn, 'newDocument');
             else
-                obj.doc = invoke(obj.mn, 'openDocument', filePath);
+                obj.doc = invoke(obj.mn, 'openDocument', fileName);
             end
                 obj.view = invoke(obj.doc, 'getview');
                 obj.consts = invoke(obj.mn, 'getConstants');
                 obj.setDefaultLengthUnit(obj.defaultLength, false);
          end
         
-         function save(obj, path, fileName)
-            % SAVE Saves the MagNet document in the specified path
-            filePath = fullfile(path, fileName);
+         function save(obj, fileName)
+            % SAVE Save the MagNet document.
+            % fileName is a string that specifies the complete path to the file.
             invoke(obj.mn, 'processcommand',...
-                     sprintf('Call getDocument().save("%s")',filePath)); 
+                     sprintf('Call getDocument().save("%s")',fileName)); 
          end
          
         function close(obj)

--- a/tools/magnet/MagNet.m
+++ b/tools/magnet/MagNet.m
@@ -26,17 +26,21 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
          function open(obj, varargin)
             %OPEN Open MagNet
             %   open() opens a new instance of MagNet with a new document.
-            %   open('fileName', fileName) opens an existing MagNet document. 
-            %   fileName is a string that specifies the full filepath and 
-            %   the name of the file. It is specified as a key-value pair.
+            %   open('path', path, 'fileName', fileName) opens an existing MagNet document. 
+            %   path is a string that specifies the file path.
+            %   fileName is a string that specifies the name of the file.  
+            %   Both path and fileName are specified as a key-value pair.
             p = inputParser;
             p.addParameter('fileName','');
+            p.addParameter('path','');
             p.parse(varargin{:});
             fileName = p.Results.fileName;
-            if ~exist(fileName)
+            path = p.Results.path;
+            filePath = fullfile(path, fileName);
+            if ~exist(fileName)||~exist(path)
                 obj.doc = invoke(obj.mn, 'newDocument');
             else
-                obj.doc = invoke(obj.mn, 'openDocument', fileName);
+                obj.doc = invoke(obj.mn, 'openDocument', filePath);
             end
                 obj.view = invoke(obj.doc, 'getview');
                 obj.consts = invoke(obj.mn, 'getConstants');

--- a/tools/magnet/MagNet.m
+++ b/tools/magnet/MagNet.m
@@ -12,7 +12,7 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
         consts; %Program constants
         defaultLength = 'DimMillimeter';
         defaultAngle  = 'DimDegree';
-        defaultVisibility = 0;% Default visibility
+        visible = 0;% visibility
     end
     
     methods
@@ -20,20 +20,13 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
             obj = obj.createProps(nargin,varargin);            
             obj.validateProps();        
             obj.mn = actxserver('MagNet.Application');
-            set(obj.mn, 'Visible', obj.defaultVisibility);
+            set(obj.mn, 'Visible', obj.visible);
         end
                 
          function open(obj, fileName)
             %OPEN Open MagNet
             %   open() opens a new instance of MagNet with a new document.
-            %
-            %   open('filename') opens the file in a new instance of MagNet.
-            if nargin > 0 && ~isnumeric(fileName)
-                obj.doc = invoke(obj.mn, 'openDocument', fileName);
-            else
-                obj.doc = invoke(obj.mn, 'newDocument');
-            end
-            
+            obj.doc = invoke(obj.mn, 'newDocument');          
             obj.view = invoke(obj.doc, 'getview');
             obj.consts = invoke(obj.mn, 'getConstants');
             obj.setDefaultLengthUnit('millimeters', false);
@@ -204,11 +197,12 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
         end
         
         
-        function setVisibility(obj, visibility)
+        function setVisibility(obj, visible)
             %SETVISIBLE Sets visibility of MagNet application
-            %    setVisibility(true)
-            
-            set(obj.mn, 'Visible', visibility);
+            %    Set visible= 'true' or visible = 1 to make the MagNet
+            %    session visible. Set visible= 'false' or visible = 0 to 
+            %    make the MagNet session invisible.  
+            set(obj.mn, 'Visible', visible);
         end
     end
     

--- a/tools/magnet/MagNet.m
+++ b/tools/magnet/MagNet.m
@@ -41,7 +41,7 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
                 obj.setDefaultLengthUnit(obj.defaultLength, false);
          end
         
-         function saveas(obj, fileName)
+         function saveAs(obj, fileName)
             % SAVEAS Save the MagNet document.
             % fileName is a string that specifies the complete path to the file.
             invoke(obj.mn, 'processcommand',...
@@ -51,8 +51,12 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
          
          function save(obj)
             % SAVE Save the MagNet document.
+            if isempty(obj.fileName)
+                error('Unable to save file. Use the saveAs( ) function');
+            else
             invoke(obj.mn, 'processcommand',...
                      sprintf('Call getDocument().save("%s")',obj.fileName));
+            end
          end
          
          

--- a/tools/magnet/MagNet.m
+++ b/tools/magnet/MagNet.m
@@ -11,7 +11,7 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
         view; %View object
         consts; %Program constants
         defaultLength = 'DimMillimeter';
-        defaultAngle  = 'DimDegree'
+        defaultAngle  = 'DimDegree';
     end
     
     methods

--- a/tools/magnet/MagNet.m
+++ b/tools/magnet/MagNet.m
@@ -23,12 +23,17 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
             set(obj.mn, 'Visible', obj.visible);
         end
                 
-         function open(obj, fileName)
+         function open(obj, varargin)
             %OPEN Open MagNet
             %   open() opens a new instance of MagNet with a new document.
-            %   open(fileName) opens an existing MagNet document. fileName
-            %   is a string that has the full filepath and the file name.
-            if isempty(fileName)
+            %   open('fileName', fileName) opens an existing MagNet document. 
+            %   fileName is a string that specifies the full filepath and 
+            %   the name of the file. It is specified as a key-value pair.
+            p = inputParser;
+            p.addParameter('fileName','');
+            p.parse(varargin{:});
+            fileName = p.Results.fileName;
+            if ~exist(fileName)
                 obj.doc = invoke(obj.mn, 'newDocument');
             else
                 obj.doc = invoke(obj.mn, 'openDocument', fileName);

--- a/tools/magnet/MagNet.m
+++ b/tools/magnet/MagNet.m
@@ -40,7 +40,7 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
             end
                 obj.view = invoke(obj.doc, 'getview');
                 obj.consts = invoke(obj.mn, 'getConstants');
-                obj.setDefaultLengthUnit('millimeters', false);
+                obj.setDefaultLengthUnit(obj.defaultLength, false);
          end
         
          function save(obj, path, fileName)
@@ -173,31 +173,23 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
             %SETDEFAULTLENGTHUNIT Set the default unit for length.
             %   setDefaultLengthUnit(userUnit, makeAppDefault)
             %       Sets the units for length. 
-
             %   userUnit can be one of these options:
-            %       'kilometers'
-            %       'meters'
-            %       'centimeters'
-            %       'millimeters'
-            %		'microns'
-            %		'miles'
-            %		'yards'	
-            %		'feet'
-            %       'inches'
+            %       'DimMillimeter'
+            %       'DimInch'
             %
             %   This is a wrapper for Document::setDefaultLengthUnit
 
             %update length unit type, this is needed for unit conversions
             %in extruding/drawing/moving/etc. (not yet implemented).
-            if strcmp(userUnit, 'millimeters')
-                obj.defaultLength = 'DimMillimeter';
-            elseif strcmp(userUnit, 'inches')
-                obj.defaultLength = 'DimInches';
+            if strcmp(userUnit,'DimMillimeter')
+                appUnit = 'millimeters';
+            elseif strcmp(userUnit, 'DimInches')
+                appUnit = 'inches';
             else
                 error('unsupported length unit')
             end
             
-            invoke(obj.doc, 'setDefaultLengthUnit', userUnit, makeAppDefault);
+            invoke(obj.doc, 'setDefaultLengthUnit', appUnit, makeAppDefault);
         end
         
         function viewAll(obj)

--- a/tools/magnet/MagNet.m
+++ b/tools/magnet/MagNet.m
@@ -51,14 +51,23 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
             obj.view = invoke(obj.doc, 'getview');
             obj.consts = invoke(obj.mn, 'getConstants');
             obj.setDefaultLengthUnit('millimeters', false);
+         end
+        
+         function save(obj, path, fileName)
+            % SAVE Saves the MagNet document in the specified path
+            filePath = fullfile(path, fileName);
+            invoke(obj.mn, 'processcommand',...
+                     sprintf('Call getDocument().save("%s")',filePath)); 
+         end
+         
+        function close(obj)
+           % CLOSE Closes the MagNet document
+           invoke (obj.mn, 'processcommand','Call getDocument().close(False)');
         end
         
-        function close(obj)
-           % CLOSE Closes MagNet application
-           %     close()
-           
-           % TODO:
-           % Implement this...
+        function delete(obj)
+           % DELETE Closes the MagNet application
+            invoke(obj.mn, 'processcommand','call close(False)');
         end
         
         function setCores(obj, numCores)

--- a/tools/magnet/MagNet.m
+++ b/tools/magnet/MagNet.m
@@ -44,9 +44,8 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
          function saveAs(obj, fileName)
             % SAVEAS Save the MagNet document.
             % fileName is a string that specifies the complete path to the file.
-            invoke(obj.mn, 'processcommand',...
-                     sprintf('Call getDocument().save("%s")',fileName));
             obj.fileName = fileName;
+            obj.save();
          end
          
          function save(obj)
@@ -216,6 +215,7 @@ classdef MagNet < ToolBase & DrawerBase & MakerExtrudeBase & MakerRevolveBase
             %    session visible. Set visible= 'false' or visible = 0 to 
             %    make the MagNet session invisible.  
             set(obj.mn, 'Visible', visible);
+            obj.visible = visible;
         end
     end
     


### PR DESCRIPTION
This PR is does the following:

1. Update MATLAB MagNet tool to separate responsibility between `open ( )` and the constructor function. 
   a. The constructor creates a MagNet instance and sets its visibility.
   b. The `open( )` function only opens a MagNet document.
   
2. Implement `save ( )` function to save the drawn / solved MagNet model. Ideally before closing, but can be used at any point.

3. Implement `close ( )` function to close the MagNet document

4. Implement the destructor function  `delete ( )` function to close the MagNet instance and destroy the object.
   
5. Update `exampleParallelogram` to demonstrate the workflow.

6. Ignore files with extensions `.mn` - These are MagNet FEA files that we typically do not want in the repo.

The workflow is as follows:
`constructor` -- > `open( )` --> (Use plumbing / porcelain functions) --> `save( )` -- > `close( )` --> `delete( )`  

Updates:
1. This PR also updates the  `ToolBase` by adding `save`, `saveAs`, and additional arguments to `open`

2. Examples have been updated to use the new function signatures.