### PR TITLE
Fix crossects dimensions

### DIFF
--- a/model_obj/crosssects/breadloaf/CrossSectBreadloaf.m
+++ b/model_obj/crosssects/breadloaf/CrossSectBreadloaf.m
@@ -31,14 +31,14 @@ classdef CrossSectBreadloaf < CrossSectBase
             %calculate coordinates each point starting in bottom right
             %corner and moving counterclockwise around the breadloaf
             
-            p1 = [ w/2, 0 ];
+            p1 = [ w/2, feval(class(w), 0)];
             p2 = [ w/2 - l*cos(alpha),  l*sin(alpha) ];
             p3 = [-w/2 + l*cos(alpha),  l*sin(alpha) ];
-            p4 = [-w/2, 0 ];
+            p4 = [-w/2, feval(class(w), 0)];
             
             beta = asin(p2(1)/r);
             base = r*cos(beta);
-            arcCenter = [0, -(base - p2(2))];
+            arcCenter = [feval(class(w), 0), -(base - p2(2))];
             
             %transform coords
             p1 = obj.location.transformCoords(p1);
@@ -53,7 +53,7 @@ classdef CrossSectBreadloaf < CrossSectBase
             [leftSeg]   = drawer.drawLine(p3, p4);
             [baseSeg]  = drawer.drawLine(p4, p1);
             
-            innerCoord = obj.location.transformCoords( [0, l*sin(alpha)/2] );
+            innerCoord = obj.location.transformCoords([feval(class(w), 0), l*sin(alpha)/2] );
 
             segments = [rightSeg, arc, leftSeg, baseSeg];
             csToken = CrossSectToken(innerCoord, segments);

--- a/model_obj/crosssects/hollowCylinder/CrossSectHollowCylinder.m
+++ b/model_obj/crosssects/hollowCylinder/CrossSectHollowCylinder.m
@@ -21,8 +21,8 @@ classdef CrossSectHollowCylinder < CrossSectBase
             r = obj.dim_r_o;
             t = obj.dim_t;                  
             
-            x_out = 0;
-            x_in = 0;
+            x_out = feval(class(t), 0);
+            x_in = feval(class(t), 0);
             x = [x_out, x_out, x_in, x_in];
             
             y_out = r;

--- a/model_obj/crosssects/hollowRectangle/CrossSectHollowRect.m
+++ b/model_obj/crosssects/hollowRectangle/CrossSectHollowRect.m
@@ -21,13 +21,13 @@ classdef CrossSectHollowRect < CrossSectBase
                 
         function [csToken] = draw(obj, drawer)
             validateattributes(drawer, {'DrawerBase'}, {'nonempty'});
-            axis = DimMillimeter([0,0]);
             w=obj.dim_w;
             h=obj.dim_h;
             t1=obj.dim_t1;
             t2=obj.dim_t2;
             t3=obj.dim_t3;
-            t4=obj.dim_t4;            
+            t4=obj.dim_t4;
+            axis = DimMillimeter([feval(class(w), 0),feval(class(w), 0)]);
          
             % Create inner and outer points
             points_i=[axis(1)+t3,axis(2)+t4; axis(1)+t3,axis(2)+h-t2;...

--- a/model_obj/crosssects/hollowRectangle/CrossSectHollowRect.m
+++ b/model_obj/crosssects/hollowRectangle/CrossSectHollowRect.m
@@ -27,7 +27,7 @@ classdef CrossSectHollowRect < CrossSectBase
             t2=obj.dim_t2;
             t3=obj.dim_t3;
             t4=obj.dim_t4;
-            axis = [feval(class(w), 0),feval(class(w), 0)];
+            axis = feval(class(w), [0,0]);
          
             % Create inner and outer points
             points_i=[axis(1)+t3,axis(2)+t4; axis(1)+t3,axis(2)+h-t2;...

--- a/model_obj/crosssects/hollowRectangle/CrossSectHollowRect.m
+++ b/model_obj/crosssects/hollowRectangle/CrossSectHollowRect.m
@@ -27,7 +27,7 @@ classdef CrossSectHollowRect < CrossSectBase
             t2=obj.dim_t2;
             t3=obj.dim_t3;
             t4=obj.dim_t4;
-            axis = DimMillimeter([feval(class(w), 0),feval(class(w), 0)]);
+            axis = [feval(class(w), 0),feval(class(w), 0)];
          
             % Create inner and outer points
             points_i=[axis(1)+t3,axis(2)+t4; axis(1)+t3,axis(2)+h-t2;...


### PR DESCRIPTION
This PR fixes the following cross-sects to properly use dimensions: 

- `breadloaf`, 

- `hollowCylinder`

- `hollowRectangle`