### PR TITLE
Add inner notched rotor cross-section

### DIFF
--- a/python/emach/model_obj/cross_sects/__init__.py
+++ b/python/emach/model_obj/cross_sects/__init__.py
@@ -1,6 +1,7 @@
 
 from .hollow_cylinder import *
+from .inner_notched_rotor import *
 
 __all__ = []
 __all__ += hollow_cylinder.__all__
-
+__all__ += inner_notched_rotor.__all__

--- a/python/emach/model_obj/cross_sects/inner_notched_rotor/CrossSectInnerNotchedRotor.svg
+++ b/python/emach/model_obj/cross_sects/inner_notched_rotor/CrossSectInnerNotchedRotor.svg
@@ -1,0 +1,933 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="CrossSectInnerNotchedRotor.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 210 297"
+   height="297mm"
+   width="210mm">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker1395"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1393"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1;fill:#ff0000;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker1241"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1;fill:#ff0000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path1239" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker4620"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path4618"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4460"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lstart">
+      <path
+         transform="scale(0.8) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path4458" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker3818"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3816"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker3676"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path3674"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker3052"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path3050" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker2910"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path2908"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker2738"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2736"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker2632"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path2630"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker2324"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path2322" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2073"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lstart">
+      <path
+         transform="scale(0.8) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path2071" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker1985"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1983"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker1903"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path1901"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker1756"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path1754" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1692"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lstart">
+      <path
+         transform="scale(0.8) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path1690" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker1634"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path1632"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker1358"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path1356"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible;"
+       id="marker1306"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend">
+      <path
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path1304" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1231"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lstart">
+      <path
+         transform="scale(0.8) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path1229" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lstart">
+      <path
+         transform="scale(0.8) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path879" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker1169"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path1167"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1;fill:#ff0000;fill-opacity:1"
+         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+    </marker>
+    <path
+       stroke-width="1"
+       id="MJMATHI-78"
+       d="M52 289Q59 331 106 386T222 442Q257 442 286 424T329 379Q371 442 430 442Q467 442 494 420T522 361Q522 332 508 314T481 292T458 288Q439 288 427 299T415 328Q415 374 465 391Q454 404 425 404Q412 404 406 402Q368 386 350 336Q290 115 290 78Q290 50 306 38T341 26Q378 26 414 59T463 140Q466 150 469 151T485 153H489Q504 153 504 145Q504 144 502 134Q486 77 440 33T333 -11Q263 -11 227 52Q186 -10 133 -10H127Q78 -10 57 16T35 71Q35 103 54 123T99 143Q142 143 142 101Q142 81 130 66T107 46T94 41L91 40Q91 39 97 36T113 29T132 26Q168 26 194 71Q203 87 217 139T245 247T261 313Q266 340 266 352Q266 380 251 392T217 404Q177 404 142 372T93 290Q91 281 88 280T72 278H58Q52 284 52 289Z" />
+    <path
+       stroke-width="1"
+       id="MJMAIN-3D"
+       d="M56 347Q56 360 70 367H707Q722 359 722 347Q722 336 708 328L390 327H72Q56 332 56 347ZM56 153Q56 168 72 173H708Q722 163 722 153Q722 140 707 133H70Q56 140 56 153Z" />
+    <path
+       stroke-width="1"
+       id="MJMAIN-73"
+       d="M295 316Q295 356 268 385T190 414Q154 414 128 401Q98 382 98 349Q97 344 98 336T114 312T157 287Q175 282 201 278T245 269T277 256Q294 248 310 236T342 195T359 133Q359 71 321 31T198 -10H190Q138 -10 94 26L86 19L77 10Q71 4 65 -1L54 -11H46H42Q39 -11 33 -5V74V132Q33 153 35 157T45 162H54Q66 162 70 158T75 146T82 119T101 77Q136 26 198 26Q295 26 295 104Q295 133 277 151Q257 175 194 187T111 210Q75 227 54 256T33 318Q33 357 50 384T93 424T143 442T187 447H198Q238 447 268 432L283 424L292 431Q302 440 314 448H322H326Q329 448 335 442V310L329 304H301Q295 310 295 316Z" />
+    <path
+       stroke-width="1"
+       id="MJMAIN-69"
+       d="M69 609Q69 637 87 653T131 669Q154 667 171 652T188 609Q188 579 171 564T129 549Q104 549 87 564T69 609ZM247 0Q232 3 143 3Q132 3 106 3T56 1L34 0H26V46H42Q70 46 91 49Q100 53 102 60T104 102V205V293Q104 345 102 359T88 378Q74 385 41 385H30V408Q30 431 32 431L42 432Q52 433 70 434T106 436Q123 437 142 438T171 441T182 442H185V62Q190 52 197 50T232 46H255V0H247Z" />
+    <path
+       stroke-width="1"
+       id="MJMAIN-6E"
+       d="M41 46H55Q94 46 102 60V68Q102 77 102 91T102 122T103 161T103 203Q103 234 103 269T102 328V351Q99 370 88 376T43 385H25V408Q25 431 27 431L37 432Q47 433 65 434T102 436Q119 437 138 438T167 441T178 442H181V402Q181 364 182 364T187 369T199 384T218 402T247 421T285 437Q305 442 336 442Q450 438 463 329Q464 322 464 190V104Q464 66 466 59T477 49Q498 46 526 46H542V0H534L510 1Q487 2 460 2T422 3Q319 3 310 0H302V46H318Q379 46 379 62Q380 64 380 200Q379 335 378 343Q372 371 358 385T334 402T308 404Q263 404 229 370Q202 343 195 315T187 232V168V108Q187 78 188 68T191 55T200 49Q221 46 249 46H265V0H257L234 1Q210 2 183 2T145 3Q42 3 33 0H25V46H41Z" />
+    <path
+       stroke-width="1"
+       id="MJMATHI-3C0"
+       d="M132 -11Q98 -11 98 22V33L111 61Q186 219 220 334L228 358H196Q158 358 142 355T103 336Q92 329 81 318T62 297T53 285Q51 284 38 284Q19 284 19 294Q19 300 38 329T93 391T164 429Q171 431 389 431Q549 431 553 430Q573 423 573 402Q573 371 541 360Q535 358 472 358H408L405 341Q393 269 393 222Q393 170 402 129T421 65T431 37Q431 20 417 5T381 -10Q370 -10 363 -7T347 17T331 77Q330 86 330 121Q330 170 339 226T357 318T367 358H269L268 354Q268 351 249 275T206 114T175 17Q164 -11 132 -11Z" />
+    <path
+       stroke-width="1"
+       id="MJMATHI-3B1"
+       d="M34 156Q34 270 120 356T309 442Q379 442 421 402T478 304Q484 275 485 237V208Q534 282 560 374Q564 388 566 390T582 393Q603 393 603 385Q603 376 594 346T558 261T497 161L486 147L487 123Q489 67 495 47T514 26Q528 28 540 37T557 60Q559 67 562 68T577 70Q597 70 597 62Q597 56 591 43Q579 19 556 5T512 -10H505Q438 -10 414 62L411 69L400 61Q390 53 370 41T325 18T267 -2T203 -11Q124 -11 79 39T34 156ZM208 26Q257 26 306 47T379 90L403 112Q401 255 396 290Q382 405 304 405Q235 405 183 332Q156 292 139 224T121 120Q121 71 146 49T208 26Z" />
+    <path
+       stroke-width="1"
+       id="MJMATHI-72"
+       d="M21 287Q22 290 23 295T28 317T38 348T53 381T73 411T99 433T132 442Q161 442 183 430T214 408T225 388Q227 382 228 382T236 389Q284 441 347 441H350Q398 441 422 400Q430 381 430 363Q430 333 417 315T391 292T366 288Q346 288 334 299T322 328Q322 376 378 392Q356 405 342 405Q286 405 239 331Q229 315 224 298T190 165Q156 25 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 114 189T154 366Q154 405 128 405Q107 405 92 377T68 316T57 280Q55 278 41 278H27Q21 284 21 287Z" />
+    <path
+       stroke-width="1"
+       id="MJMATHI-70"
+       d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z" />
+    <path
+       stroke-width="1"
+       id="MJMATHI-78-7"
+       d="M52 289Q59 331 106 386T222 442Q257 442 286 424T329 379Q371 442 430 442Q467 442 494 420T522 361Q522 332 508 314T481 292T458 288Q439 288 427 299T415 328Q415 374 465 391Q454 404 425 404Q412 404 406 402Q368 386 350 336Q290 115 290 78Q290 50 306 38T341 26Q378 26 414 59T463 140Q466 150 469 151T485 153H489Q504 153 504 145Q504 144 502 134Q486 77 440 33T333 -11Q263 -11 227 52Q186 -10 133 -10H127Q78 -10 57 16T35 71Q35 103 54 123T99 143Q142 143 142 101Q142 81 130 66T107 46T94 41L91 40Q91 39 97 36T113 29T132 26Q168 26 194 71Q203 87 217 139T245 247T261 313Q266 340 266 352Q266 380 251 392T217 404Q177 404 142 372T93 290Q91 281 88 280T72 278H58Q52 284 52 289Z" />
+    <path
+       stroke-width="1"
+       id="MJMAIN-3D-7"
+       d="M56 347Q56 360 70 367H707Q722 359 722 347Q722 336 708 328L390 327H72Q56 332 56 347ZM56 153Q56 168 72 173H708Q722 163 722 153Q722 140 707 133H70Q56 140 56 153Z" />
+    <path
+       stroke-width="1"
+       id="MJMAIN-73-7"
+       d="M295 316Q295 356 268 385T190 414Q154 414 128 401Q98 382 98 349Q97 344 98 336T114 312T157 287Q175 282 201 278T245 269T277 256Q294 248 310 236T342 195T359 133Q359 71 321 31T198 -10H190Q138 -10 94 26L86 19L77 10Q71 4 65 -1L54 -11H46H42Q39 -11 33 -5V74V132Q33 153 35 157T45 162H54Q66 162 70 158T75 146T82 119T101 77Q136 26 198 26Q295 26 295 104Q295 133 277 151Q257 175 194 187T111 210Q75 227 54 256T33 318Q33 357 50 384T93 424T143 442T187 447H198Q238 447 268 432L283 424L292 431Q302 440 314 448H322H326Q329 448 335 442V310L329 304H301Q295 310 295 316Z" />
+    <path
+       stroke-width="1"
+       id="MJMAIN-69-0"
+       d="M69 609Q69 637 87 653T131 669Q154 667 171 652T188 609Q188 579 171 564T129 549Q104 549 87 564T69 609ZM247 0Q232 3 143 3Q132 3 106 3T56 1L34 0H26V46H42Q70 46 91 49Q100 53 102 60T104 102V205V293Q104 345 102 359T88 378Q74 385 41 385H30V408Q30 431 32 431L42 432Q52 433 70 434T106 436Q123 437 142 438T171 441T182 442H185V62Q190 52 197 50T232 46H255V0H247Z" />
+    <path
+       stroke-width="1"
+       id="MJMAIN-6E-7"
+       d="M41 46H55Q94 46 102 60V68Q102 77 102 91T102 122T103 161T103 203Q103 234 103 269T102 328V351Q99 370 88 376T43 385H25V408Q25 431 27 431L37 432Q47 433 65 434T102 436Q119 437 138 438T167 441T178 442H181V402Q181 364 182 364T187 369T199 384T218 402T247 421T285 437Q305 442 336 442Q450 438 463 329Q464 322 464 190V104Q464 66 466 59T477 49Q498 46 526 46H542V0H534L510 1Q487 2 460 2T422 3Q319 3 310 0H302V46H318Q379 46 379 62Q380 64 380 200Q379 335 378 343Q372 371 358 385T334 402T308 404Q263 404 229 370Q202 343 195 315T187 232V168V108Q187 78 188 68T191 55T200 49Q221 46 249 46H265V0H257L234 1Q210 2 183 2T145 3Q42 3 33 0H25V46H41Z" />
+    <path
+       stroke-width="1"
+       id="MJMATHI-3C0-3"
+       d="M132 -11Q98 -11 98 22V33L111 61Q186 219 220 334L228 358H196Q158 358 142 355T103 336Q92 329 81 318T62 297T53 285Q51 284 38 284Q19 284 19 294Q19 300 38 329T93 391T164 429Q171 431 389 431Q549 431 553 430Q573 423 573 402Q573 371 541 360Q535 358 472 358H408L405 341Q393 269 393 222Q393 170 402 129T421 65T431 37Q431 20 417 5T381 -10Q370 -10 363 -7T347 17T331 77Q330 86 330 121Q330 170 339 226T357 318T367 358H269L268 354Q268 351 249 275T206 114T175 17Q164 -11 132 -11Z" />
+    <path
+       stroke-width="1"
+       id="MJMATHI-3B1-8"
+       d="M34 156Q34 270 120 356T309 442Q379 442 421 402T478 304Q484 275 485 237V208Q534 282 560 374Q564 388 566 390T582 393Q603 393 603 385Q603 376 594 346T558 261T497 161L486 147L487 123Q489 67 495 47T514 26Q528 28 540 37T557 60Q559 67 562 68T577 70Q597 70 597 62Q597 56 591 43Q579 19 556 5T512 -10H505Q438 -10 414 62L411 69L400 61Q390 53 370 41T325 18T267 -2T203 -11Q124 -11 79 39T34 156ZM208 26Q257 26 306 47T379 90L403 112Q401 255 396 290Q382 405 304 405Q235 405 183 332Q156 292 139 224T121 120Q121 71 146 49T208 26Z" />
+    <path
+       stroke-width="1"
+       id="MJMATHI-72-8"
+       d="M21 287Q22 290 23 295T28 317T38 348T53 381T73 411T99 433T132 442Q161 442 183 430T214 408T225 388Q227 382 228 382T236 389Q284 441 347 441H350Q398 441 422 400Q430 381 430 363Q430 333 417 315T391 292T366 288Q346 288 334 299T322 328Q322 376 378 392Q356 405 342 405Q286 405 239 331Q229 315 224 298T190 165Q156 25 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 114 189T154 366Q154 405 128 405Q107 405 92 377T68 316T57 280Q55 278 41 278H27Q21 284 21 287Z" />
+    <path
+       stroke-width="1"
+       id="MJMATHI-70-5"
+       d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z" />
+    <path
+       stroke-width="1"
+       id="MJMATHI-6D"
+       d="M21 287Q22 293 24 303T36 341T56 388T88 425T132 442T175 435T205 417T221 395T229 376L231 369Q231 367 232 367L243 378Q303 442 384 442Q401 442 415 440T441 433T460 423T475 411T485 398T493 385T497 373T500 364T502 357L510 367Q573 442 659 442Q713 442 746 415T780 336Q780 285 742 178T704 50Q705 36 709 31T724 26Q752 26 776 56T815 138Q818 149 821 151T837 153Q857 153 857 145Q857 144 853 130Q845 101 831 73T785 17T716 -10Q669 -10 648 17T627 73Q627 92 663 193T700 345Q700 404 656 404H651Q565 404 506 303L499 291L466 157Q433 26 428 16Q415 -11 385 -11Q372 -11 364 -4T353 8T350 18Q350 29 384 161L420 307Q423 322 423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 181Q151 335 151 342Q154 357 154 369Q154 405 129 405Q107 405 92 377T69 316T57 280Q55 278 41 278H27Q21 284 21 287Z" />
+    <path
+       stroke-width="1"
+       id="MJMATHI-78-1"
+       d="M52 289Q59 331 106 386T222 442Q257 442 286 424T329 379Q371 442 430 442Q467 442 494 420T522 361Q522 332 508 314T481 292T458 288Q439 288 427 299T415 328Q415 374 465 391Q454 404 425 404Q412 404 406 402Q368 386 350 336Q290 115 290 78Q290 50 306 38T341 26Q378 26 414 59T463 140Q466 150 469 151T485 153H489Q504 153 504 145Q504 144 502 134Q486 77 440 33T333 -11Q263 -11 227 52Q186 -10 133 -10H127Q78 -10 57 16T35 71Q35 103 54 123T99 143Q142 143 142 101Q142 81 130 66T107 46T94 41L91 40Q91 39 97 36T113 29T132 26Q168 26 194 71Q203 87 217 139T245 247T261 313Q266 340 266 352Q266 380 251 392T217 404Q177 404 142 372T93 290Q91 281 88 280T72 278H58Q52 284 52 289Z" />
+    <path
+       stroke-width="1"
+       id="MJMAIN-3D-72"
+       d="M56 347Q56 360 70 367H707Q722 359 722 347Q722 336 708 328L390 327H72Q56 332 56 347ZM56 153Q56 168 72 173H708Q722 163 722 153Q722 140 707 133H70Q56 140 56 153Z" />
+    <path
+       stroke-width="1"
+       id="MJMAIN-73-2"
+       d="M295 316Q295 356 268 385T190 414Q154 414 128 401Q98 382 98 349Q97 344 98 336T114 312T157 287Q175 282 201 278T245 269T277 256Q294 248 310 236T342 195T359 133Q359 71 321 31T198 -10H190Q138 -10 94 26L86 19L77 10Q71 4 65 -1L54 -11H46H42Q39 -11 33 -5V74V132Q33 153 35 157T45 162H54Q66 162 70 158T75 146T82 119T101 77Q136 26 198 26Q295 26 295 104Q295 133 277 151Q257 175 194 187T111 210Q75 227 54 256T33 318Q33 357 50 384T93 424T143 442T187 447H198Q238 447 268 432L283 424L292 431Q302 440 314 448H322H326Q329 448 335 442V310L329 304H301Q295 310 295 316Z" />
+    <path
+       stroke-width="1"
+       id="MJMAIN-69-5"
+       d="M69 609Q69 637 87 653T131 669Q154 667 171 652T188 609Q188 579 171 564T129 549Q104 549 87 564T69 609ZM247 0Q232 3 143 3Q132 3 106 3T56 1L34 0H26V46H42Q70 46 91 49Q100 53 102 60T104 102V205V293Q104 345 102 359T88 378Q74 385 41 385H30V408Q30 431 32 431L42 432Q52 433 70 434T106 436Q123 437 142 438T171 441T182 442H185V62Q190 52 197 50T232 46H255V0H247Z" />
+    <path
+       stroke-width="1"
+       id="MJMAIN-6E-9"
+       d="M41 46H55Q94 46 102 60V68Q102 77 102 91T102 122T103 161T103 203Q103 234 103 269T102 328V351Q99 370 88 376T43 385H25V408Q25 431 27 431L37 432Q47 433 65 434T102 436Q119 437 138 438T167 441T178 442H181V402Q181 364 182 364T187 369T199 384T218 402T247 421T285 437Q305 442 336 442Q450 438 463 329Q464 322 464 190V104Q464 66 466 59T477 49Q498 46 526 46H542V0H534L510 1Q487 2 460 2T422 3Q319 3 310 0H302V46H318Q379 46 379 62Q380 64 380 200Q379 335 378 343Q372 371 358 385T334 402T308 404Q263 404 229 370Q202 343 195 315T187 232V168V108Q187 78 188 68T191 55T200 49Q221 46 249 46H265V0H257L234 1Q210 2 183 2T145 3Q42 3 33 0H25V46H41Z" />
+    <path
+       stroke-width="1"
+       id="MJMATHI-3C0-2"
+       d="M132 -11Q98 -11 98 22V33L111 61Q186 219 220 334L228 358H196Q158 358 142 355T103 336Q92 329 81 318T62 297T53 285Q51 284 38 284Q19 284 19 294Q19 300 38 329T93 391T164 429Q171 431 389 431Q549 431 553 430Q573 423 573 402Q573 371 541 360Q535 358 472 358H408L405 341Q393 269 393 222Q393 170 402 129T421 65T431 37Q431 20 417 5T381 -10Q370 -10 363 -7T347 17T331 77Q330 86 330 121Q330 170 339 226T357 318T367 358H269L268 354Q268 351 249 275T206 114T175 17Q164 -11 132 -11Z" />
+    <path
+       stroke-width="1"
+       id="MJMATHI-3B1-5"
+       d="M34 156Q34 270 120 356T309 442Q379 442 421 402T478 304Q484 275 485 237V208Q534 282 560 374Q564 388 566 390T582 393Q603 393 603 385Q603 376 594 346T558 261T497 161L486 147L487 123Q489 67 495 47T514 26Q528 28 540 37T557 60Q559 67 562 68T577 70Q597 70 597 62Q597 56 591 43Q579 19 556 5T512 -10H505Q438 -10 414 62L411 69L400 61Q390 53 370 41T325 18T267 -2T203 -11Q124 -11 79 39T34 156ZM208 26Q257 26 306 47T379 90L403 112Q401 255 396 290Q382 405 304 405Q235 405 183 332Q156 292 139 224T121 120Q121 71 146 49T208 26Z" />
+    <path
+       stroke-width="1"
+       id="MJMATHI-72-3"
+       d="M21 287Q22 290 23 295T28 317T38 348T53 381T73 411T99 433T132 442Q161 442 183 430T214 408T225 388Q227 382 228 382T236 389Q284 441 347 441H350Q398 441 422 400Q430 381 430 363Q430 333 417 315T391 292T366 288Q346 288 334 299T322 328Q322 376 378 392Q356 405 342 405Q286 405 239 331Q229 315 224 298T190 165Q156 25 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 114 189T154 366Q154 405 128 405Q107 405 92 377T68 316T57 280Q55 278 41 278H27Q21 284 21 287Z" />
+    <path
+       stroke-width="1"
+       id="MJMATHI-70-2"
+       d="M23 287Q24 290 25 295T30 317T40 348T55 381T75 411T101 433T134 442Q209 442 230 378L240 387Q302 442 358 442Q423 442 460 395T497 281Q497 173 421 82T249 -10Q227 -10 210 -4Q199 1 187 11T168 28L161 36Q160 35 139 -51T118 -138Q118 -144 126 -145T163 -148H188Q194 -155 194 -157T191 -175Q188 -187 185 -190T172 -194Q170 -194 161 -194T127 -193T65 -192Q-5 -192 -24 -194H-32Q-39 -187 -39 -183Q-37 -156 -26 -148H-6Q28 -147 33 -136Q36 -130 94 103T155 350Q156 355 156 364Q156 405 131 405Q109 405 94 377T71 316T59 280Q57 278 43 278H29Q23 284 23 287ZM178 102Q200 26 252 26Q282 26 310 49T356 107Q374 141 392 215T411 325V331Q411 405 350 405Q339 405 328 402T306 393T286 380T269 365T254 350T243 336T235 326L232 322Q232 321 229 308T218 264T204 212Q178 106 178 102Z" />
+    <path
+       stroke-width="1"
+       id="MJMATHI-6D-5"
+       d="M21 287Q22 293 24 303T36 341T56 388T88 425T132 442T175 435T205 417T221 395T229 376L231 369Q231 367 232 367L243 378Q303 442 384 442Q401 442 415 440T441 433T460 423T475 411T485 398T493 385T497 373T500 364T502 357L510 367Q573 442 659 442Q713 442 746 415T780 336Q780 285 742 178T704 50Q705 36 709 31T724 26Q752 26 776 56T815 138Q818 149 821 151T837 153Q857 153 857 145Q857 144 853 130Q845 101 831 73T785 17T716 -10Q669 -10 648 17T627 73Q627 92 663 193T700 345Q700 404 656 404H651Q565 404 506 303L499 291L466 157Q433 26 428 16Q415 -11 385 -11Q372 -11 364 -4T353 8T350 18Q350 29 384 161L420 307Q423 322 423 345Q423 404 379 404H374Q288 404 229 303L222 291L189 157Q156 26 151 16Q138 -11 108 -11Q95 -11 87 -5T76 7T74 17Q74 30 112 181Q151 335 151 342Q154 357 154 369Q154 405 129 405Q107 405 92 377T69 316T57 280Q55 278 41 278H27Q21 284 21 287Z" />
+    <path
+       stroke-width="1"
+       id="MJMATHI-73"
+       d="M131 289Q131 321 147 354T203 415T300 442Q362 442 390 415T419 355Q419 323 402 308T364 292Q351 292 340 300T328 326Q328 342 337 354T354 372T367 378Q368 378 368 379Q368 382 361 388T336 399T297 405Q249 405 227 379T204 326Q204 301 223 291T278 274T330 259Q396 230 396 163Q396 135 385 107T352 51T289 7T195 -10Q118 -10 86 19T53 87Q53 126 74 143T118 160Q133 160 146 151T160 120Q160 94 142 76T111 58Q109 57 108 57T107 55Q108 52 115 47T146 34T201 27Q237 27 263 38T301 66T318 97T323 122Q323 150 302 164T254 181T195 196T148 231Q131 256 131 289Z" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:window-height="1027"
+     inkscape:window-width="2560"
+     showgrid="false"
+     inkscape:current-layer="layer1-1"
+     inkscape:document-units="mm"
+     inkscape:cy="464.42524"
+     inkscape:cx="484.46325"
+     inkscape:zoom="1.4"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <g
+       transform="translate(0.67793058,23.50348)"
+       inkscape:label="Layer 1"
+       id="layer1-2">
+      <g
+         id="layer1-1"
+         inkscape:label="Layer 1"
+         transform="translate(-12.97233,1.6968079)">
+        <path
+           sodipodi:open="true"
+           d="m 89.17284,50.692497 a 74.768623,81.910934 0 0 1 33.72167,71.487453 74.768623,81.910934 0 0 1 -38.389437,68.60377"
+           sodipodi:end="1.0634136"
+           sodipodi:start="5.292744"
+           sodipodi:ry="81.910934"
+           sodipodi:rx="74.768623"
+           sodipodi:cy="119.19199"
+           sodipodi:cx="48.175644"
+           sodipodi:type="arc"
+           id="path815"
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.70999998;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;" />
+        <path
+           sodipodi:open="true"
+           d="m 148.94694,141.60993 a 77.108177,101.39132 0 0 1 -3.88684,17.77662"
+           sodipodi:end="0.37129713"
+           sodipodi:start="0.18861399"
+           sodipodi:ry="101.39132"
+           sodipodi:rx="77.108177"
+           sodipodi:cy="122.5993"
+           sodipodi:cx="73.206268"
+           sodipodi:type="arc"
+           id="path815-3"
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.67941463;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;" />
+        <path
+           sodipodi:open="true"
+           d="m 144.06266,84.471823 a 80.934151,97.466675 0 0 1 4.89705,19.930317"
+           sodipodi:end="6.102321"
+           sodipodi:start="5.8886673"
+           sodipodi:ry="97.466675"
+           sodipodi:rx="80.934151"
+           sodipodi:cy="121.93443"
+           sodipodi:cx="69.345711"
+           sodipodi:type="arc"
+           id="path815-3-5"
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.68246174;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;" />
+        <path
+           sodipodi:open="true"
+           d="M 112.21364,35.441235 A 83.635704,99.22834 0 0 1 131.60872,54.77604"
+           sodipodi:end="5.5632223"
+           sodipodi:start="5.2591587"
+           sodipodi:ry="99.22834"
+           sodipodi:rx="83.635704"
+           sodipodi:cy="120.20293"
+           sodipodi:cx="68.728874"
+           sodipodi:type="arc"
+           id="path815-3-0"
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.69999999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;" />
+        <path
+           sodipodi:open="true"
+           d="m 130.73174,189.3308 a 83.635704,99.22834 0 0 1 -22.63115,21.38104"
+           sodipodi:end="1.0721393"
+           sodipodi:start="0.7244885"
+           sodipodi:ry="99.22834"
+           sodipodi:rx="83.635704"
+           sodipodi:cy="123.56697"
+           sodipodi:cx="68.102104"
+           sodipodi:type="arc"
+           id="path815-3-3"
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.69999999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;" />
+        <path
+           d="m 120.16191,64.27791 a 75.495529,89.928085 0 0 1 11.99394,24.945021"
+           sodipodi:open="true"
+           sodipodi:end="5.9235762"
+           sodipodi:start="5.6025371"
+           sodipodi:ry="89.928085"
+           sodipodi:rx="75.495529"
+           sodipodi:cy="120.86938"
+           sodipodi:cx="61.489433"
+           sodipodi:type="arc"
+           id="path865"
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.69999999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path869"
+           d="m 125.20992,59.830626 c 0,0 0,0 -74.384522,62.913674 L 138.99745,86.477514"
+           style="fill:none;stroke:#666666;stroke-width:0.34557089;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.07342528, 2.07342527999999993;stroke-dashoffset:0;stroke-opacity:1;" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path871"
+           d="m 51.051117,122.18921 74.093373,62.61991"
+           style="fill:none;stroke:#666666;stroke-width:0.336;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.016, 2.01600000000000001;stroke-dashoffset:0;stroke-opacity:1;" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path873"
+           d="m 51.199788,122.73695 56.914342,87.44952"
+           style="fill:none;stroke:#666666;stroke-width:0.37014562;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.22087376, 2.22087375999999992;stroke-dashoffset:0;stroke-opacity:1;" />
+        <text
+           id="text877"
+           y="122.73537"
+           x="78.87751"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;"
+           xml:space="preserve" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1275"
+           d="m 89.950127,63.413752 6.366414,-6.209937"
+           style="fill:none;stroke:#000000;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1306);" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path1275-9"
+           d="m 106.17037,47.184954 5.04643,-6.084802"
+           style="fill:none;stroke:#000000;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker1231);" />
+        <text
+           transform="scale(0.94563926,1.0574857)"
+           id="text1608"
+           y="91.631638"
+           x="143.78827"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.1994px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.216641"
+           xml:space="preserve"><tspan
+             style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.46667px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';stroke-width:0.216641"
+             y="91.631638"
+             x="143.78827"
+             id="tspan1606"
+             sodipodi:role="line">d<tspan
+   id="tspan1125"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub">rs</tspan></tspan></text>
+        <path
+           d="m 143.39102,50.32412 a 90.885773,108.25831 0 0 1 -0.85234,141.72843"
+           sodipodi:open="true"
+           sodipodi:end="0.7208184"
+           sodipodi:start="5.5766934"
+           sodipodi:ry="108.25831"
+           sodipodi:rx="90.885773"
+           sodipodi:cy="120.6021"
+           sodipodi:cx="74.259308"
+           sodipodi:type="arc"
+           id="path1612"
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.44;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#marker1692);marker-end:url(#marker1756);" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path1878"
+           d="m 123.78456,99.204433 8.55262,-2.672696"
+           style="fill:none;stroke:#000000;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1903);" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path1878-4"
+           d="m 147.5811,92.074109 8.55262,-2.672695"
+           style="fill:none;stroke:#000000;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker1985);" />
+        <text
+           transform="scale(0.95120969,1.0512929)"
+           id="text1608-9"
+           y="51.923031"
+           x="103.17177"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.06799px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.211166"
+           xml:space="preserve"><tspan
+             style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.46667px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';stroke-width:0.211166"
+             y="51.923031"
+             x="103.17177"
+             id="tspan1606-5"
+             sodipodi:role="line">d<tspan
+   id="tspan1130"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub">ri</tspan></tspan></text>
+        <path
+           inkscape:connector-curvature="0"
+           id="path2282"
+           d="m 99.478953,181.77634 7.647227,7.66637"
+           style="fill:none;stroke:#000000;stroke-width:0.30000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2324);" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path2284"
+           d="m 118.91036,202.87627 8.07089,9.14357"
+           style="fill:none;stroke:#000000;stroke-width:0.26826194;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker2073);" />
+        <text
+           transform="scale(0.94663621,1.056372)"
+           id="text1608-6"
+           y="186.08144"
+           x="114.82695"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.06691px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.211121"
+           xml:space="preserve"><tspan
+             style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.46667px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';stroke-width:0.211121"
+             y="186.08144"
+             x="114.82695"
+             id="tspan1606-0"
+             sodipodi:role="line">d<tspan
+   id="tspan1127"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub">rp</tspan></tspan></text>
+        <path
+           sodipodi:open="true"
+           d="m 66.874968,109.69142 a 21.381561,20.579754 0 0 1 1.225419,25.69291"
+           sodipodi:end="0.62911067"
+           sodipodi:start="5.5623265"
+           sodipodi:ry="20.579754"
+           sodipodi:rx="21.381561"
+           sodipodi:cy="123.27467"
+           sodipodi:cx="50.812302"
+           sodipodi:type="arc"
+           id="path2607-9"
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#marker2738);marker-end:url(#marker2910);" />
+        <path
+           sodipodi:open="true"
+           d="m 90.821371,89.28569 a 51.850288,49.979401 0 0 1 9.077637,13.71892"
+           sodipodi:end="5.8789391"
+           sodipodi:start="5.5519127"
+           sodipodi:ry="49.979401"
+           sodipodi:rx="51.850288"
+           sodipodi:cy="122.6628"
+           sodipodi:cx="52.227898"
+           sodipodi:type="arc"
+           id="path2607-2"
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#marker3818);marker-end:url(#marker3676);" />
+        <g
+           style="fill:currentColor;stroke:currentColor;stroke-width:0;"
+           transform="matrix(0.00597048,0,0,-0.00670664,72.753524,117.8773)"
+           id="g4131" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4450"
+           d="M 51.431621,122.03691 104.51968,66.079116"
+           style="fill:none;stroke:#000000;stroke-width:0.36494392;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker4460);marker-end:url(#marker4620);" />
+        <text
+           transform="scale(0.98772612,1.0124264)"
+           id="text4849"
+           y="127.38773"
+           x="64.671745"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.7811px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:#ff0000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+           xml:space="preserve"><tspan
+             style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.46667px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';fill:#000000;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+             y="127.38773"
+             x="64.671745"
+             id="tspan4847"
+             sodipodi:role="line">x</tspan></text>
+        <text
+           transform="scale(0.98772612,1.0124264)"
+           id="text4849-8"
+           y="95.804321"
+           x="48.096207"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.46667px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+           xml:space="preserve"><tspan
+             style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.46667px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';fill:#000000;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+             y="95.804321"
+             x="48.096207"
+             id="tspan4847-4"
+             sodipodi:role="line">y</tspan></text>
+        <text
+           transform="rotate(90)"
+           id="text4887"
+           y="-169.04839"
+           x="97.14257"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.46667px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';stroke-width:0.264583"
+             y="-169.04839"
+             x="97.14257"
+             id="tspan4885"
+             sodipodi:role="line">Pole Pitch</tspan></text>
+        <path
+           d="m 136.05659,108.76668 a 75.548447,88.852699 0 0 1 -1.06442,30.25442"
+           sodipodi:open="true"
+           sodipodi:end="0.21258617"
+           sodipodi:start="6.1533081"
+           sodipodi:ry="88.852699"
+           sodipodi:rx="75.548447"
+           sodipodi:cy="120.2742"
+           sodipodi:cx="61.144432"
+           sodipodi:type="arc"
+           id="path865-3"
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.69604582;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;" />
+        <path
+           d="m 130.89111,154.60059 a 75.495529,89.928085 0 0 1 -12.40419,24.10487"
+           sodipodi:open="true"
+           sodipodi:end="0.70775241"
+           sodipodi:start="0.39204763"
+           sodipodi:ry="89.928085"
+           sodipodi:rx="75.495529"
+           sodipodi:cy="120.24073"
+           sodipodi:cx="61.123528"
+           sodipodi:type="arc"
+           id="path865-3-1"
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.69999999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path1115"
+           d="m 117.905,178.64499 12.75066,11.13453"
+           style="fill:none;stroke:#000000;stroke-width:0.69999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path1117"
+           d="M 145.11187,159.3078 130.44301,154.861"
+           style="fill:none;stroke:#000000;stroke-width:0.69999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path1121"
+           d="m 135.13966,138.77839 13.72975,2.93606"
+           style="fill:none;stroke:#000000;stroke-width:0.70905721;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path1123"
+           d="m 132.03114,89.331577 12.02713,-4.81085"
+           style="fill:none;stroke:#000000;stroke-width:0.69999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path1125"
+           d="M 119.76443,64.696451 131.7362,54.344111"
+           style="fill:none;stroke:#000000;stroke-width:0.69999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path1129"
+           d="m 136.30746,109.10952 12.82893,-5.07812"
+           style="fill:none;stroke:#000000;stroke-width:0.69999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;" />
+        <path
+           d="m 131.81927,89.786372 a 75.495529,89.928085 0 0 1 4.17958,19.425528"
+           sodipodi:open="true"
+           sodipodi:end="6.1440233"
+           sodipodi:start="5.9205653"
+           sodipodi:ry="89.928085"
+           sodipodi:rx="75.495529"
+           sodipodi:cy="121.68612"
+           sodipodi:cx="61.23317"
+           sodipodi:type="arc"
+           id="path865-3-1-6"
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#666666;stroke-width:0.30000001;stroke-miterlimit:4;stroke-dasharray:0.3, 0.59999999999999998;stroke-dashoffset:0;stroke-opacity:1;" />
+        <path
+           d="m 118.1623,178.93913 a 75.495529,89.928085 0 0 1 -18.624097,18.8327"
+           sodipodi:open="true"
+           sodipodi:end="1.0294452"
+           sodipodi:start="0.70442227"
+           sodipodi:ry="89.928085"
+           sodipodi:rx="75.495529"
+           sodipodi:cy="120.70227"
+           sodipodi:cx="60.63578"
+           sodipodi:type="arc"
+           id="path865-3-1-6-5"
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#666666;stroke-width:0.30000001;stroke-miterlimit:4;stroke-dasharray:0.3, 0.60000001000000003;stroke-dashoffset:0;stroke-opacity:1;" />
+        <path
+           d="M 97.102078,42.078341 A 75.495529,89.928085 0 0 1 119.8537,63.899756"
+           sodipodi:open="true"
+           sodipodi:end="5.584968"
+           sodipodi:start="5.1956007"
+           sodipodi:ry="89.928085"
+           sodipodi:rx="75.495529"
+           sodipodi:cy="121.71031"
+           sodipodi:cx="62.024925"
+           sodipodi:type="arc"
+           id="path865-3-1-6-4"
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#666666;stroke-width:0.30000001;stroke-miterlimit:4;stroke-dasharray:0.3, 0.60000001000000003;stroke-dashoffset:0;stroke-opacity:1;" />
+        <text
+           xml:space="preserve"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;"
+           x="76.744728"
+           y="117.83556"
+           id="text4035" />
+        <text
+           xml:space="preserve"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;"
+           x="74.812233"
+           y="128.62532"
+           id="text4039" />
+        <text
+           xml:space="preserve"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583;"
+           x="75.375877"
+           y="124.92138"
+           id="text4043" />
+        <text
+           xml:space="preserve"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           x="73.471329"
+           y="123.20389"
+           id="text4055"><tspan
+             sodipodi:role="line"
+             id="tspan4053"
+             x="73.471329"
+             y="123.20389"
+             style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.46667px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';stroke-width:0.264583">α<tspan
+   id="tspan1119"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub">rm</tspan></tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           x="96.458725"
+           y="94.910553"
+           id="text4055-2"><tspan
+             sodipodi:role="line"
+             id="tspan4053-0"
+             x="96.458725"
+             y="94.910553"
+             style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8.46667px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';stroke-width:0.264583">α<tspan
+   id="tspan1122"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub">rs</tspan></tspan></text>
+        <text
+           id="text1489"
+           y="224.36371"
+           x="123.72194"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.264583"
+             y="224.36371"
+             x="123.72194"
+             id="tspan1487"
+             sodipodi:role="line">p = <tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, '"
+   id="tspan1300">number of pole pairs</tspan></tspan></text>
+        <text
+           id="text1489-6"
+           y="234.09018"
+           x="122.28637"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.264583"
+             y="234.09018"
+             x="122.28637"
+             id="tspan1487-1"
+             sodipodi:role="line">s = <tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, '"
+   id="tspan1298">number of segments/pole</tspan></tspan></text>
+        <path
+           id="path1237"
+           d="M 50.825397,98.567396 V 122.46147 H 70.240866"
+           style="fill:none;stroke:#ff0000;stroke-width:0.357;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker1395);marker-end:url(#marker1241);" />
+        <text
+           id="text1113"
+           y="93.862213"
+           x="64.266129"
+           style="font-size:8.46667px;line-height:0.95;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="font-size:8.46667px;stroke-width:0.264583"
+             y="93.862213"
+             x="64.266129"
+             id="tspan1111"
+             sodipodi:role="line"><tspan
+               id="tspan1117"
+               style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic'">r</tspan><tspan
+               id="tspan1115"
+               style="font-size:65%;baseline-shift:sub">ri</tspan></tspan></text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/python/emach/model_obj/cross_sects/inner_notched_rotor/README.md
+++ b/python/emach/model_obj/cross_sects/inner_notched_rotor/README.md
@@ -1,0 +1,3 @@
+# Inner Notched Rotor Cross Section
+
+<img src="./CrossSectInnerNotchedRotor.svg" width="900" height="900" />

--- a/python/emach/model_obj/cross_sects/inner_notched_rotor/__init__.py
+++ b/python/emach/model_obj/cross_sects/inner_notched_rotor/__init__.py
@@ -2,6 +2,7 @@
 import numpy as np
 
 from ...dimensions.dim_linear import DimLinear
+from ...dimensions.dim_angular import DimAngular
 from ...dimensions import DimRadian
 from ..cross_sect_base import CrossSectBase, CrossSectToken
 
@@ -27,7 +28,7 @@ class CrossSectInnerNotchedRotor(CrossSectBase):
         self._create_attr(kwargs)  
         
         super()._validate_attr()
-        # self._validate_attr()
+        self._validate_attr()
     
     @property
     def dim_alpha_rm(self):
@@ -187,12 +188,47 @@ class CrossSectInnerNotchedRotor(CrossSectBase):
         
     def _validate_attr(self):
         
-        if isinstance(self._dim_r_o, DimLinear):
+        if isinstance(self._dim_alpha_rm, DimAngular):
             pass
         else:
-            raise TypeError("dim_r_o not of type DimLinear")
+            raise TypeError("dim_alpha_rm not of type DimAngular")
             
-        if isinstance(self._dim_t, DimLinear):
+        if isinstance(self._dim_alpha_rs, DimAngular):
             pass
         else:
-            raise TypeError("dim_t not of type DimLinear")     
+            raise TypeError("dim_alpha_rs not of type DimAngular")
+            
+        if isinstance(self._dim_r_ri, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_ri not of type DimLinear")
+            
+        if isinstance(self._dim_d_ri, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_ri not of type DimLinear")    
+        
+        if isinstance(self._dim_d_rp, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_rp not of type DimLinear")    
+            
+        if isinstance(self._dim_d_rs, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_rs not of type DimLinear")
+        
+        if isinstance(self._s, int):
+            pass
+        else:
+            raise TypeError("s not of type int")
+            
+        if isinstance(self._p, int):
+            pass
+        else:
+            raise TypeError("p not of type int")
+            
+            
+            
+            
+            

--- a/python/emach/model_obj/cross_sects/inner_notched_rotor/__init__.py
+++ b/python/emach/model_obj/cross_sects/inner_notched_rotor/__init__.py
@@ -1,0 +1,198 @@
+
+import numpy as np
+
+from ...dimensions.dim_linear import DimLinear
+from ...dimensions import DimRadian
+from ..cross_sect_base import CrossSectBase, CrossSectToken
+
+__all__ = ['CrossSectInnerNotchedRotor']
+class CrossSectInnerNotchedRotor(CrossSectBase):
+    
+    def __init__(self, **kwargs: any) -> None: 
+        '''
+        Intialization function for HollowCylinder class. This function takes in
+        arguments and saves the information passed to private variable to make
+        them read-only
+        Parameters
+        ----------
+        **kwargs : any
+            DESCRIPTION. Keyword arguments provided to the initialization funcntion.
+            The following argument names have to be included in order for the code
+            to execute: name, dim_t, dim_r_o, location. 
+            
+        Returns
+        -------
+        None
+        '''
+        self._create_attr(kwargs)  
+        
+        super()._validate_attr()
+        # self._validate_attr()
+    
+    @property
+    def dim_alpha_rm(self):
+        return self._dim_alpha_rm
+    
+    @property
+    def dim_alpha_rs(self):
+        return self._dim_alpha_rs
+    
+    @property
+    def dim_r_ri(self):
+        return self._dim_r_ri
+    
+    @property
+    def dim_d_ri(self):
+        return self._dim_d_ri
+    
+    @property
+    def dim_d_rp(self):
+        return self._dim_d_rp
+    
+    @property
+    def dim_d_rs(self):
+        return self._dim_d_rs
+    
+    @property
+    def p(self):
+        return self._p
+    
+    @property
+    def s(self):
+        return self._s   
+        
+    def draw(self, drawer):
+
+        alpha_rm = DimRadian(self._dim_alpha_rm)
+        alpha_rs = DimRadian(self._dim_alpha_rs)
+        r_ri = self._dim_r_ri
+        d_ri = self._dim_d_ri
+        d_rp = self._dim_d_rp
+        d_rs = self._dim_d_rs
+        p = self._p
+        s = self._s
+        P = 2*p
+        alpha_rp = 2*np.pi/P
+        alpha_k = (alpha_rm-(alpha_rs*s))/(s-1)
+        
+# Compute angles of various rotor segment start and end points           
+        if s % 2 == 1:
+            prev_theta_m = -alpha_rs/2
+            prev_theta_ms = 0;
+            angle = np.zeros(s+1)
+            for i in range(0,s+1):
+                if i % 2 == 0:
+                    theta_m= prev_theta_m + alpha_rs
+                    prev_theta_m = theta_m;
+                else:
+                    theta_ms = prev_theta_ms + alpha_k
+                    prev_theta_ms = theta_ms
+                
+            angle[i] = prev_theta_m + prev_theta_ms;
+
+        else:
+            prev_theta_ms = -alpha_k/2
+            prev_theta_m = 0;
+            angle = np.zeros(s+1)
+            for i in range(0,s+1):
+                if i % 2 == 1:
+                   theta_m = prev_theta_m + alpha_rs
+                   prev_theta_m = theta_m
+                else:
+                   theta_ms = prev_theta_ms + alpha_k
+                   prev_theta_ms = theta_ms
+                 
+                angle[i] = prev_theta_m + prev_theta_ms;
+                  
+# Assign angle for the end point of the interpolar segment            
+        angle[-1] = angle[-2]+(alpha_rp-alpha_rm)
+            
+# Generate coordinates based on the points angles
+        a = np.zeros(s+1)  
+        y = np.zeros(s+1) 
+        x = np.zeros(s+1)
+        zx = np.zeros(s+1)
+        zy = np.zeros(s+1)
+        for i in range(0,s+1):
+            if (i<=s-2):
+                a[i] = r_ri+d_ri+d_rs;
+            else:
+                a[i] = r_ri+d_ri+d_rp;
+            
+            y[i] = a[i]*np.sin(angle[i]);
+            x[i] = a[i]*np.cos(angle[i]);
+            zx[i] = (r_ri+d_ri)*np.cos((angle[i]));
+            zy[i] = (r_ri + d_ri)*np.sin((angle[i]));
+        
+
+# Reshape the coordinates for drawing    
+
+        flip_x = x[::-1]
+        flip_x = flip_x[1:]
+        x_array = np.append(flip_x, x) 
+        
+        flip_y = -1*y[::-1]
+        flip_y = flip_y[1:]
+        y_array = np.append(flip_y, y) 
+        
+        flip_zx = zx[::-1]
+        flip_zx = flip_zx[1:]
+        zx_array = np.append(flip_zx, zx) 
+        
+        flip_zy = -1*zy[::-1]
+        flip_zy = flip_zy[1:]
+        zy_array = np.append(flip_zy, zy) 
+        
+        points = np.zeros([len(x_array),2])
+        inner_points = np.zeros([len(x_array),2])
+        for l in range(0,len(x_array)):
+            points[l,0] = x_array[l]
+            points[l,1] = y_array[l]
+            inner_points[l,0] = zx_array[l]
+            inner_points[l,1] = zy_array[l]
+            
+# Draw p poles with s segments per pole    
+               
+        for i in range(1,P+1):
+            points = self.location.transform_coords(points, DimRadian(2*np.pi/P))
+            inner_points = self.location.transform_coords(inner_points, DimRadian(2*np.pi/P))
+            arc = []
+            lines = []
+            for j in range(0,2*s+1):
+                if j % 2 == 1:
+                    arc.append(drawer.draw_arc(self.location.anchor_xy, points[j,:],points[j+1,:]))
+                    lines.append(drawer.draw_line(points[j,:,], inner_points[j,:]))
+                 
+                if (j % 2 == 0 and j<(2*s)):
+                    arc.append(drawer.draw_arc(self.location.anchor_xy, inner_points[j,:],inner_points[j+1,:]))
+                    lines.append(drawer.draw_line(points[j,:,], inner_points[j,:]))  
+
+# Draw inner surface          
+        if (r_ri == 0):
+            point_i = self.location.anchor_xy
+            inner_coord = self.location.transform_coords(np.array([[point_i]]))
+            cs_token = CrossSectToken(inner_coord, arc)
+            
+        else:
+           point_i = [r_ri,0]+self.location.anchor_xy
+           point_i2 = [-r_ri,0]+self.location.anchor_xy
+           arc_i1 = drawer.draw_arc(self.location.anchor_xy, point_i,point_i2)
+           arc_i2 = drawer.draw_arc(self.location.anchor_xy, point_i2,point_i)
+           rad = r_ri+d_ri
+           inner_coord = self.location.transform_coords(np.array([[rad, type(r_ri)(0)]]))
+           segments = [arc,arc_i1,arc_i2]
+           cs_token = CrossSectToken(inner_coord[0,:], segments)
+
+        return cs_token
+        
+    def _validate_attr(self):
+        
+        if isinstance(self._dim_r_o, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_o not of type DimLinear")
+            
+        if isinstance(self._dim_t, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_t not of type DimLinear")     

--- a/python/examples/example_inner_notched_rotor_cross.py
+++ b/python/examples/example_inner_notched_rotor_cross.py
@@ -1,0 +1,37 @@
+# add the directory immediately above this file's directory to path for module import
+import sys
+sys.path.append("..")
+
+import emach.tools.magnet as mn
+import emach.model_obj as mo
+import numpy as np
+
+x = mo.DimMillimeter(4)
+y = mo.DimMillimeter(80)
+z = mo.DimMillimeter(40)
+
+# create CrossSectInnerNotchedRotor object
+innerNotchedRotor1 = mo.CrossSectInnerNotchedRotor(name = 'rotor',
+                                             location = mo.Location2D(),
+                                             dim_alpha_rm = mo.DimDegree(60), 
+                                             dim_alpha_rs = mo.DimDegree(10),
+                                             dim_d_ri = mo.DimMillimeter(8),
+                                             dim_r_ri = mo.DimMillimeter(40),
+                                             dim_d_rp = mo.DimMillimeter(5), 
+                                             dim_d_rs = mo.DimMillimeter(3),
+                                             p = 2, s = 4)
+
+
+
+
+# create an instance of the MagNet class
+toolMn = mn.MagNet(visible=True)
+toolMn.open()
+
+# draw inner notched rotor
+c1 = innerNotchedRotor1.draw(toolMn)
+
+toolMn.view_all()
+# select inner coordinate of cross-section
+toolMn.prepare_section(c1)
+


### PR DESCRIPTION
This PR adds inner notched rotor cross-section drawing capability to the `Python` implementation of `eMach`. The example script corresponding to this cross-section is `python/examples/example_inner_notched_rotor_cross.py`