### PR TITLE
Add inner rotor stator cross-section

### DIFF
--- a/python/emach/model_obj/cross_sects/__init__.py
+++ b/python/emach/model_obj/cross_sects/__init__.py
@@ -1,6 +1,7 @@
 
 from .hollow_cylinder import *
+from .inner_rotor_stator import *
 
 __all__ = []
 __all__ += hollow_cylinder.__all__
-
+__all__ += inner_rotor_stator.__all__

--- a/python/emach/model_obj/cross_sects/inner_rotor_stator/CrossSectInnerRotorStator.svg
+++ b/python/emach/model_obj/cross_sects/inner_rotor_stator/CrossSectInnerRotorStator.svg
@@ -1,0 +1,1792 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="150"
+   inkscape:export-xdpi="150"
+   inkscape:export-filename="C:\Users\nheme\Documents\Research\Bearingless Motor\Bearinless_Parametrization_Rev1_wht_bckgrnd.png"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="CrossSectInnerRotorStator.svg"
+   id="svg837"
+   version="1.1"
+   viewBox="0 0 180 243"
+   height="243mm"
+   width="180mm">
+  <defs
+     id="defs831">
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3363"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3361"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2957"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2955"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2473"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2471"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2091"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path2089" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1611"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1609"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4727"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4725"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4345"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4343"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3969"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3967"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3599"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3597"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2905"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path2903" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3124"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path3122" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1741"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1739"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1387"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1385" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker12119"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path12117" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker11779"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path11777" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4333"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4331"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3967"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3965" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3691"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3689"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3429"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path3427"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.2,0,0,0.2,1.2,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2019"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2017"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1781"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1779"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(0.3,0,0,0.3,-0.69,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1488"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1486" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1244"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1242" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker16235"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path16233"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15733"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15731"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker15525"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path15523"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker10501"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path10499" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker10219"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path10217"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9500"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9498" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9322"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path9320" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8927"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8925" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker8563"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path8561"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8403"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8401" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8209"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8207" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker8061"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path8059" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7820"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7818"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7684"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path7682"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6757"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6755"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6627"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path6625"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker6012"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path6010" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker5894"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path5892" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5567"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5565"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5461"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5459"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5080"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path5078"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4986"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4984" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4450"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4448" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4374"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4372"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3864"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path3862" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mstart">
+      <path
+         transform="matrix(0.4,0,0,0.4,4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1491" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart">
+      <path
+         transform="matrix(0.2,0,0,0.2,1.2,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1497" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1939"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1937" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart">
+      <path
+         transform="matrix(0.3,0,0,0.3,-0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1515" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Send"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1518" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow2Mstart"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Mstart">
+      <path
+         transform="scale(0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1509" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="Arrow1Mend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1494" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4128-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4126-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4852-2-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4850-0-3"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker10501-1"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path10499-0"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker10501-1-7"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path10499-0-3"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:collect="always"
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker10501-6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path10499-4"
+         inkscape:connector-curvature="0" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     height="281mm"
+     inkscape:document-rotation="0"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="false"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-others="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:window-height="1027"
+     inkscape:window-width="2560"
+     inkscape:guide-bbox="true"
+     showguides="false"
+     showborder="true"
+     showgrid="false"
+     inkscape:current-layer="g1476"
+     inkscape:document-units="mm"
+     inkscape:cy="460.59012"
+     inkscape:cx="-555.61786"
+     inkscape:zoom="0.70710682"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata834">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:none"
+     inkscape:label="Background"
+     id="layer5"
+     inkscape:groupmode="layer" />
+  <g
+     style="display:none"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Total_Motor">
+    <path
+       inkscape:connector-curvature="0"
+       id="path1388"
+       transform="scale(0.26458333)"
+       d="M 0,650.07812 A 472.4409,472.4409 0 0 0 -472.44141,1122.5195 472.4409,472.4409 0 0 0 0,1594.9609 472.4409,472.4409 0 0 0 472.44141,1122.5195 472.4409,472.4409 0 0 0 0,650.07812 Z m -62.580078,131.7168 c 2.119773,-0.0633 4.238058,0.0941 6.103516,0.6543 2.541358,0.7632 4.943413,2.47682 6.457031,4.65625 1.450551,2.08861 2.260179,4.14371 2.77539,6.56445 v 96.20703 l -32.126953,32.12696 v 25.01171 A 192.85715,192.85715 0 0 1 0,929.66211 192.85715,192.85715 0 0 1 79.371094,946.94922 V 922.00391 L 47.244141,889.87695 v -96.1914 c 0.515003,-2.42755 1.32369,-4.487 2.777343,-6.58008 1.513618,-2.17943 3.915677,-3.89305 6.457032,-4.65625 1.645518,-0.49416 3.491159,-0.65631 5.357422,-0.64844 A 347.10338,347.10338 0 0 1 262.25586,895.70703 c 1.75673,2.4167 3.37685,5.15152 4.01758,7.86524 0.60972,2.58247 0.32595,5.51939 -0.80469,7.91992 -1.08536,2.30442 -2.46502,4.03425 -4.30859,5.69336 l -83.3086,48.09765 -43.88476,-11.75781 -21.66211,12.50586 a 192.85715,192.85715 0 0 1 54.71484,60.06055 192.85715,192.85715 0 0 1 24.71485,77.3809 L 213.33789,1091 l 11.75781,-43.8867 83.31055,-48.09963 c 2.35704,-0.76605 4.54514,-1.093 7.08203,-0.88086 2.64428,0.2211 5.33009,1.4444 7.26172,3.26369 1.49012,1.4034 2.72559,3.2743 3.76172,5.248 a 347.10338,347.10338 0 0 1 20.5918,115.875 347.10338,347.10338 0 0 1 -20.0625,114.8164 c -1.13505,2.3551 -2.53462,4.6543 -4.28907,6.3067 -1.93162,1.8193 -4.61553,3.0425 -7.25976,3.2636 -2.5387,0.2123 -4.72893,-0.1155 -7.08789,-0.8828 l -83.3086,-48.0976 -11.75781,-43.8848 -21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -24.65625,77.414 192.85715,192.85715 0 0 1 -54.65625,60.0938 l 21.60352,12.4726 43.88476,-11.7597 83.30664,48.0976 c 1.84358,1.6591 3.22324,3.3889 4.3086,5.6934 1.13066,2.4005 1.41246,5.3374 0.80273,7.9199 -0.38563,1.6333 -1.14266,3.2715 -2.05273,4.8496 A 347.10338,347.10338 0 0 1 63.15625,1463.209 c -2.309571,0.1107 -4.639833,-0.01 -6.673828,-0.6192 -2.541351,-0.7632 -4.94539,-2.4748 -6.458984,-4.6543 -1.45523,-2.0953 -2.264404,-4.1588 -2.779297,-6.5898 v -96.1836 l 32.126953,-32.1269 v -25.0118 A 192.85715,192.85715 0 0 1 0,1315.377 192.85715,192.85715 0 0 1 -79.371094,1298.0898 v 24.9454 l 32.126953,32.1269 v 96.1914 c -0.514998,2.4276 -1.323687,4.489 -2.777343,6.582 -1.513614,2.1795 -3.915681,3.8911 -6.457032,4.6543 -1.645521,0.4942 -3.491159,0.6564 -5.357422,0.6485 A 347.10338,347.10338 0 0 1 -262.22656,1349.3672 c -1.76655,-2.4252 -3.39721,-5.1736 -4.04102,-7.9004 -0.60972,-2.5825 -0.32791,-5.5194 0.80274,-7.9199 1.08656,-2.307 2.46775,-4.0385 4.31445,-5.6992 l 83.29883,-48.0918 43.88476,11.7597 21.66211,-12.5058 a 192.85715,192.85715 0 0 1 -54.71484,-60.0606 192.85715,192.85715 0 0 1 -24.71485,-77.3808 l -21.60351,12.4726 -11.75781,43.8848 -83.31055,48.0996 c -2.35704,0.766 -4.54513,1.093 -7.08203,0.8808 -2.64427,-0.2211 -5.33009,-1.4443 -7.26172,-3.2636 -1.49012,-1.4035 -2.72559,-3.2744 -3.76172,-5.2481 a 347.10338,347.10338 0 0 1 -20.5918,-115.875 347.10338,347.10338 0 0 1 20.04688,-114.7754 c 1.13845,-2.3696 2.54575,-4.6855 4.31055,-6.3476 1.93163,-1.81929 4.61551,-3.04259 7.25976,-3.26369 2.53416,-0.21191 4.7201,0.11466 7.07422,0.87891 l 83.31641,48.10158 11.75781,43.8867 21.66211,12.5059 a 192.85715,192.85715 0 0 1 24.65625,-77.4141 192.85715,192.85715 0 0 1 54.65625,-60.09571 l -21.60352,-12.4707 -43.88476,11.75781 -83.30664,-48.09765 c -1.84358,-1.65911 -3.22324,-3.38894 -4.3086,-5.69336 -1.13063,-2.40057 -1.41246,-5.33745 -0.80273,-7.91992 0.3858,-1.63403 1.14211,-3.27284 2.05273,-4.85157 A 347.10338,347.10338 0 0 1 -63.158203,781.83008 c 0.193318,-0.009 0.38466,-0.0294 0.578125,-0.0352 z"
+       style="opacity:1;fill:#008000;fill-opacity:1;stroke:#000000;stroke-width:3.77953;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <circle
+       r="43.733097"
+       cy="297"
+       cx="0"
+       id="path1390"
+       style="opacity:1;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1.09333;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     style="display:none"
+     inkscape:label="Motor_Cutaway"
+     id="layer2"
+     inkscape:groupmode="layer" />
+  <g
+     style="display:none"
+     inkscape:label="Annotations_1"
+     id="layer3"
+     inkscape:groupmode="layer">
+    <path
+       inkscape:connector-curvature="0"
+       id="path5884"
+       d="M -7.5563861,234.90369 V 206.70526"
+       style="fill:none;stroke:#000000;stroke-width:0.259632px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6012);marker-end:url(#marker5894)" />
+    <rect
+       y="218.84871"
+       x="-8.3674479"
+       height="2.2158854"
+       width="1.5875"
+       id="rect6524"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1464"
+       d="M -0.02743323,297.01265 35.30925,221.27907"
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.202531;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.810125, 0.202531;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 0,297 -35.336683,221.26642"
+       id="path1466"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1470"
+       d="M -21.000268,250.56454 V 221.26642"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="csc"
+       inkscape:connector-curvature="0"
+       id="path1482"
+       d="m -11.797594,270.57892 c 3.5813579,-1.66871 7.5752744,-2.60053 11.78682858,-2.60053 4.23356982,0 8.24722062,0.94159 11.84295942,2.62676"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Sstart);marker-end:url(#Arrow2Send);paint-order:normal" />
+    <g
+       transform="translate(-23.187493,-34.196779)"
+       id="g1919">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect1907"
+         width="6.160902"
+         height="5.5858846"
+         x="20.12562"
+         y="299.38223" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="20.947077"
+         y="304.3931"
+         id="text1895"><tspan
+           sodipodi:role="line"
+           id="tspan1893"
+           x="20.947077"
+           y="304.3931"
+           style="stroke-width:0.264583">θ<tspan
+   style="font-size:3.52778px"
+   id="tspan1897">t</tspan></tspan></text>
+    </g>
+    <flowRoot
+       transform="scale(0.26458333)"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:24px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       id="flowRoot1899"
+       xml:space="preserve"><flowRegion
+         id="flowRegion1901"><rect
+           y="1122.5197"
+           x="61.473213"
+           height="49.675323"
+           width="50.91721"
+           id="rect1903" /></flowRegion><flowPara
+         id="flowPara1905" /></flowRoot>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path1934"
+       d="m -29.626283,232.40708 c 2.447086,-1.23671 5.213559,-1.9334 8.142751,-1.9334"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.236671;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow1Sstart);marker-end:url(#marker1939);paint-order:normal" />
+    <rect
+       y="229.11623"
+       x="-27.407322"
+       height="3.6542518"
+       width="3.6240244"
+       id="rect1927"
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.13113;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+    <text
+       id="text1923"
+       y="232.42699"
+       x="-27.561081"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="232.42699"
+         x="-27.561081"
+         id="tspan1921"
+         sodipodi:role="line">α</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3542"
+       d="m 25.501249,208.12668 8.748058,-30.47166"
+       style="fill:none;stroke:#000000;stroke-width:0.251839px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow1Mstart);marker-end:url(#marker3864)" />
+    <text
+       id="text4090"
+       y="162.72395"
+       x="57.811459"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="162.72395"
+         x="57.811459"
+         id="tspan4088"
+         sodipodi:role="line" /></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path3528"
+       d="M -12.500012,236.16224 V 246.8512"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.24847px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5567);marker-end:url(#marker5461)" />
+    <text
+       id="text4094"
+       y="173.58723"
+       x="-52.318027"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="173.58723"
+         x="-52.318027"
+         id="tspan4092"
+         sodipodi:role="line">D<tspan
+   id="tspan4096"
+   style="font-size:3.52778px">os</tspan></tspan></text>
+    <g
+       transform="translate(-16.559098,-7.3212701)"
+       id="g4116">
+      <rect
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.237103;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="rect4104"
+         width="6.6424799"
+         height="5.9479485"
+         x="43.113136"
+         y="197.23814" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="43.78854"
+         y="202.14687"
+         id="text4100"><tspan
+           sodipodi:role="line"
+           id="tspan4098"
+           x="43.78854"
+           y="202.14687"
+           style="stroke-width:0.264583">T<tspan
+   style="font-size:3.52778px"
+   id="tspan4102">s</tspan></tspan></text>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118"
+       d="m -44.334244,171.98437 h 2.000911 l 4.828646,4.82865"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4364"
+       d="m 15.718783,210.03594 -1.547002,-1.79208"
+       style="fill:none;stroke:#000000;stroke-width:0.191617;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.383234, 0.191617;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4450)" />
+    <text
+       id="text4634"
+       y="212.41602"
+       x="15.941146"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="212.41602"
+         x="15.941146"
+         id="tspan4632"
+         sodipodi:role="line">r</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4976"
+       d="M -11.547554,219.80781 H 11.547554"
+       style="fill:none;stroke:#000000;stroke-width:0.254303px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker5080);marker-end:url(#marker4986)" />
+    <g
+       transform="translate(-43.306146,19.473489)"
+       id="g4116-9">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8"
+           y="202.70813"
+           x="42.993412"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.70813"
+             x="42.993412"
+             id="tspan4098-5"
+             sodipodi:role="line">W<tspan
+   style="font-size:3.52778px"
+   id="tspan5415">t</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5449"
+       d="m -12.500012,247.56684 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5451"
+       d="m -12.500012,235.4466 h 9.8872516"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:arc-type="arc"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:0.795, 0.265;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="path5875"
+       sodipodi:type="arc"
+       sodipodi:cx="0"
+       sodipodi:cy="296.99997"
+       sodipodi:rx="91.67807"
+       sodipodi:ry="91.67807"
+       sodipodi:start="4.4466291"
+       sodipodi:end="4.5768786"
+       sodipodi:open="true"
+       d="m -24.078562,208.54042 a 91.67807,91.67807 0 0 1 11.693219,-2.37806" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5878"
+       d="m -12.500012,213.23104 v -7.0392"
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5882"
+       d="m -12.385343,206.16235 h 9.7725826"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="translate(-53.364328,27.478398)"
+       id="g4116-9-8"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7"><tspan
+   id="tspan6615"
+   style="font-size:6.35px">L</tspan>t</tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       transform="translate(-53.364328,40.708055)"
+       id="g4116-9-8-7"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-5">
+        <rect
+           y="197.24779"
+           x="42.65506"
+           height="5.928659"
+           width="7.7924948"
+           id="rect4104-4-4-1"
+           style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.256393;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+        <text
+           id="text4100-8-5-7"
+           y="202.17897"
+           x="43.456432"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="202.17897"
+             x="43.456432"
+             id="tspan4098-5-6-6"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-7"><tspan
+   id="tspan6580-5"
+   style="font-size:6.35px">L</tspan>tt</tspan></tspan></text>
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path4118-8"
+       d="m -28.486583,277.7367 h -2.000911 l -4.828646,-4.82865"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4128-8)" />
+    <text
+       id="text4094-6"
+       y="279.95316"
+       x="-28.468546"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="279.95316"
+         x="-28.468546"
+         id="tspan4092-2"
+         sodipodi:role="line">D<tspan
+   id="tspan4096-9"
+   style="font-size:3.52778px;stroke-width:0.264583">or</tspan></tspan></text>
+    <path
+       inkscape:transform-center-y="-47.336963"
+       inkscape:transform-center-x="-0.53635573"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path6617"
+       d="m 0.49341607,252.4546 0.0643483,-5.62927"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.204665px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker6757);marker-end:url(#marker6627)" />
+    <text
+       id="text4100-8-5-7-6"
+       y="251.6891"
+       x="1.700698"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="251.6891"
+         x="1.700698"
+         id="tspan4098-5-6-6-5"
+         sodipodi:role="line"><tspan
+           style="font-size:3.52778px"
+           id="tspan5415-7-7-3"><tspan
+   id="tspan6580-5-5"
+   style="font-size:6.35px">L</tspan>g</tspan></tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15507"
+       d="m 21.000268,250.54698 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.23934px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path15509"
+       d="m 21.000268,243.94686 h 8.688366"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       id="text15513"
+       y="248.73111"
+       x="25.765221"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="248.73111"
+         x="25.765221"
+         id="tspan15511"
+         sodipodi:role="line">s</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path15515"
+       d="m 27.057699,249.05852 v 0.97042"
+       style="fill:none;stroke:#000000;stroke-width:0.276484px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker15733)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path15945"
+       d="m 27.060298,245.50384 v -1.05237"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker16235)" />
+  </g>
+  <g
+     style="display:inline"
+     inkscape:label="Annotations_2"
+     id="layer4"
+     inkscape:groupmode="layer">
+    <g
+       transform="translate(-20.688286,17.424232)"
+       id="g4116-9-8-2-5"
+       style="display:inline">
+      <g
+         transform="translate(0,0.18708867)"
+         id="g5421-1-7-0">
+        <text
+           id="text4100-8-5-1-8"
+           y="202.24512"
+           x="42.629608"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+           xml:space="preserve"><tspan
+             style="stroke-width:0.264583"
+             y="0"
+             x="0"
+             id="tspan4098-5-6-1-3"
+             sodipodi:role="line"><tspan
+               style="font-size:3.52778px"
+               id="tspan5415-7-3-8"><tspan
+                 id="tspan6615-5-9"
+                 style="font-size:6.35px" /></tspan></tspan></text>
+      </g>
+    </g>
+    <g
+       transform="translate(104.775,-83.608331)"
+       id="g1476">
+      <path
+         style="fill:#999999;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1"
+         d="m -95.610927,213.56889 68.869723,-32.13406"
+         id="path9316"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="-76.185753"
+         y="216.03908"
+         id="text2115"><tspan
+           sodipodi:role="line"
+           id="tspan2113"
+           x="-76.185753"
+           y="216.03908"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.264583">x</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="-98.33429"
+         y="193.48747"
+         id="text2145"><tspan
+           sodipodi:role="line"
+           id="tspan2143"
+           x="-98.33429"
+           y="193.48747"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic';stroke-width:0.264583">y</tspan></text>
+      <path
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M -33.167151,321.72456 C 5.499536,299.42722 29.342791,258.20388 29.389236,213.56889 29.325038,168.94272 5.474689,127.73561 -33.188855,105.45043 m -36.90886,63.92788 c 6.266709,3.63682 11.687032,8.56654 15.900323,14.46113 l 3.299539,-5.71593 -3.11092,-11.61118 12.725837,-22.04155 c 0.438973,-0.48778 0.896657,-0.85281 1.506368,-1.13998 0.635151,-0.29915 1.412201,-0.37371 2.095479,-0.21239 0.432337,0.10208 0.865939,0.30218 1.283645,0.54312 16.119659,13.64823 27.0422131,32.43565 30.9273098,53.19675 0.0024,0.0512 0.0078,0.10178 0.0093,0.15296 0.01675,0.56086 -0.0249,1.12132 -0.173117,1.61489 -0.2019299,0.6724 -0.6553249,1.30795 -1.231966,1.70843 -0.552611,0.38379 -1.0963557,0.598 -1.7368437,0.73432 H -34.057525 l -8.500259,-8.50026 h -6.617682 c 3.00432,6.59464 4.569531,13.75356 4.591439,21.00027 -0.0164,7.24543 -1.575599,14.4043 -4.573881,21.00027 h 6.600114 l 8.500259,-8.50026 h 25.4506411 c 0.642289,0.13626 1.1871857,0.35023 1.7409797,0.73484 0.5766411,0.40048 1.0300361,1.03602 1.231966,1.70842 0.130746,0.43538 0.173649,0.92371 0.171566,1.41749 -3.7114417,20.59314 -14.3440528,39.3014 -30.1376958,53.02777 -0.639418,0.4648 -1.363006,0.89346 -2.081011,1.06298 -0.683278,0.16133 -1.460339,0.0862 -2.095479,-0.2129 -0.609711,-0.28717 -1.067395,-0.65221 -1.506369,-1.13999 l -12.725836,-22.04206 3.11092,-11.61118 -3.308842,-5.73143 c -4.208931,5.89921 -9.626137,10.83425 -15.89102,14.47663"
+         id="path3512"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccsccccccccccccccccccccccccc" />
+      <path
+         style="display:inline;fill:#000000;stroke:#000000;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker11779);marker-end:url(#marker12119)"
+         d="M -6.7102651,187.39667 5.992943,184.3535 m 5.89638,-1.41253 11.99045,-2.87242"
+         id="path11768"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         inkscape:transform-center-x="16.932516"
+         inkscape:transform-center-y="-62.914672" />
+      <path
+         sodipodi:arc-type="arc"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:0.795, 0.265;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="path5445"
+         sodipodi:type="arc"
+         sodipodi:cx="213.56894"
+         sodipodi:cy="95.610924"
+         sodipodi:rx="91.67807"
+         sodipodi:ry="91.67807"
+         sodipodi:start="4.5605958"
+         sodipodi:end="4.8587494"
+         sodipodi:open="true"
+         d="m 199.70621,4.9870123 a 91.67807,91.67807 0 0 1 27.23292,-0.073975"
+         transform="rotate(90)" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7564"
+         d="m -41.105674,192.56862 h 17.539471"
+         style="display:inline;fill:#999999;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path7566"
+         d="m -59.546317,197.53077 c 1.59435,3.42175 2.69367,7.12063 3.20592,11.0046 m -0.12556,10.89861 c -0.55938,3.59416 -1.62291,7.02147 -3.116,10.20736"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#marker1611);marker-end:url(#marker1488);paint-order:normal" />
+      <text
+         id="text7574"
+         y="214.8821"
+         x="-59.457684"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000"
+           y="214.8821"
+           x="-59.457684"
+           id="tspan1718"
+           sodipodi:role="line">α<tspan
+   id="tspan1720"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000">st</tspan></tspan></text>
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7578"
+         d="m -31.018005,183.9426 c 1.23671,2.44709 1.933401,5.21356 1.933401,8.14276"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#marker2957);marker-end:url(#marker3363);paint-order:normal" />
+      <text
+         id="text7584"
+         y="188.67934"
+         x="-28.749672"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583"
+           y="188.67934"
+           x="-28.749672"
+           id="tspan7582"
+           sodipodi:role="line">α<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan1772">so</tspan></tspan></text>
+      <text
+         id="text7602"
+         y="185.91504"
+         x="7.231555"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583"
+           y="185.91504"
+           x="7.231555"
+           id="tspan7600"
+           sodipodi:role="line">d<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub"
+   id="tspan1454">sy</tspan></tspan></text>
+      <text
+         id="text7612"
+         y="233.25732"
+         x="-13.807912"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583"
+           y="233.25732"
+           x="-13.807912"
+           id="tspan7610"
+           sodipodi:role="line">r<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan3056">sb</tspan></tspan></text>
+      <path
+         sodipodi:arc-type="arc"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         id="path8399"
+         sodipodi:type="arc"
+         sodipodi:cx="213.55817"
+         sodipodi:cy="95.587883"
+         sodipodi:rx="62.683178"
+         sodipodi:ry="62.683178"
+         sodipodi:start="4.5297849"
+         sodipodi:end="4.8943481"
+         sodipodi:open="true"
+         d="m 202.17547,33.946866 a 62.683178,62.683178 0 0 1 22.72564,-0.0073"
+         transform="rotate(90)" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker9322);marker-end:url(#marker8563)"
+         d="m -32.362845,213.55812 h 8.817802 m 6.184649,0 h 12.7865185"
+         id="path8727"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <path
+         style="fill:#000000;stroke:#000000;stroke-width:0.24498px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#marker8403);marker-end:url(#marker8927)"
+         d="m -33.475396,213.55812 h -3.01551 m -4.72399,0 h -2.396911"
+         id="path8905"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="-22.693655"
+         y="215.68405"
+         id="text4100-8-5-1"><tspan
+           sodipodi:role="line"
+           id="tspan4098-5-6-1"
+           x="-22.693655"
+           y="215.68405"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583"><tspan
+             id="tspan1752"
+             style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000">d</tspan><tspan
+             id="tspan5415-7-3"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000">st</tspan></tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.20298px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.258458"
+         x="-40.932148"
+         y="216.69545"
+         id="text4100-8-5-7-9"><tspan
+           sodipodi:role="line"
+           id="tspan4098-5-6-6-7"
+           x="-40.932148"
+           y="216.69545"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.258458"><tspan
+             style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.20298px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.258458"
+             id="tspan274">d</tspan><tspan
+             id="tspan5415-7-7-6"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.03194px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000;stroke-width:0.258458">sp</tspan></tspan></text>
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path9318"
+         d="m -95.610927,213.56889 45.273819,21.1244"
+         style="fill:#999999;stroke:#000000;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79375, 0.264583;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         style="fill:#000000;stroke:#000000;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker10219)"
+         d="m -16.417834,193.85743 v 6.28444"
+         id="path10209"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path10497"
+         d="M -16.417834,232.61047 V 226.9457"
+         style="fill:#000000;stroke:#000000;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker10501)" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path16215"
+         d="m -49.157907,235.78524 v 4.29728"
+         style="fill:#999999;stroke:#000000;stroke-width:0.23934px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path16217"
+         d="m -42.557787,235.78524 v 4.29728"
+         style="fill:#999999;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <text
+         id="text16221"
+         y="246.0155"
+         x="-48.3424"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583"
+           y="246.0155"
+           x="-48.3424"
+           id="tspan16219"
+           sodipodi:role="line">d<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan1746">so</tspan></tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="-16.421827"
+         y="193.30455"
+         id="text1480"><tspan
+           sodipodi:role="line"
+           id="tspan1478"
+           x="-16.421827"
+           y="193.30455"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">w<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan1482">st</tspan></tspan></text>
+      <path
+         style="fill:#000000;stroke:#000000;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker3967)"
+         d="m -95.610927,213.56889 24.51092,24.76751 m 4.3923,4.43827 6.26259,6.32816"
+         id="path3957"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <path
+         style="fill:#000000;stroke:#000000;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4333)"
+         d="m -95.610927,213.56889 56.796761,83.44634 m 3.9382,5.78604 9.003292,13.22773"
+         id="path4323"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="-70.506485"
+         y="240.57132"
+         id="text4775"><tspan
+           sodipodi:role="line"
+           id="tspan4773"
+           x="-70.506485"
+           y="240.57132"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">r<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan4777">si</tspan></tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="-39.98304"
+         y="300.44791"
+         id="text4781"><tspan
+           sodipodi:role="line"
+           id="tspan4779"
+           x="-39.98304"
+           y="300.44791"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583">r<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:65%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000"
+   id="tspan4783">so</tspan></tspan></text>
+      <text
+         id="text7612-0"
+         y="234.06877"
+         x="-28.387476"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583"
+           y="234.06877"
+           x="-28.387476"
+           id="tspan7610-9"
+           sodipodi:role="line">r<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.1275px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000;stroke-width:0.264583"
+   id="tspan3056-2">sf</tspan></tspan></text>
+      <text
+         id="text7612-5"
+         y="237.48502"
+         x="-35.231892"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.35px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#999999;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman,  Italic';fill:#000000;stroke-width:0.264583"
+           y="237.48502"
+           x="-35.231892"
+           id="tspan7610-1"
+           sodipodi:role="line">r<tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.1275px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';baseline-shift:sub;fill:#000000;stroke-width:0.264583"
+   id="tspan3056-9">st</tspan></tspan></text>
+      <path
+         inkscape:connector-curvature="0"
+         id="path10497-3"
+         d="m -28.305774,230.69494 -5.191712,-3.81989"
+         style="display:inline;fill:#000000;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker10501-1)"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path10497-3-9"
+         d="m -35.314516,235.6687 -6.407791,-0.77969"
+         style="display:inline;fill:#000000;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker10501-1-7)"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path10497-35"
+         d="m -9.6436846,230.69494 2.7829494,-2.51027"
+         style="display:inline;fill:#000000;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker10501-6)"
+         sodipodi:nodetypes="cc" />
+      <g
+         style="stroke:#ff0000"
+         id="g2173"
+         transform="rotate(90,-6.0899185,207.47908)">
+        <path
+           inkscape:connector-curvature="0"
+           id="path1377"
+           d="M 0,297 V 279.41365"
+           style="fill:none;stroke:#ff0000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1387)" />
+        <path
+           inkscape:transform-center-x="8.793175"
+           style="fill:none;stroke:#ff0000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1741)"
+           d="M 0,297 H -17.58635"
+           id="path1737"
+           inkscape:connector-curvature="0" />
+      </g>
+      <text
+         xml:space="preserve"
+         style="font-size:4.93889px;line-height:0.95;font-family:'Cambria Math';-inkscape-font-specification:'Cambria Math';stroke-width:0.264583"
+         x="-0.0053568664"
+         y="318.03043"
+         id="text1453"><tspan
+           sodipodi:role="line"
+           id="tspan1451"
+           x="-0.0053568664"
+           y="318.03043"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, ';stroke-width:0.264583"><tspan
+   style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman, Italic'"
+   id="tspan1455">Q</tspan> = number of slots</tspan></text>
+      <path
+         id="path2087"
+         d="m -48.666756,240.08252 h 5.677309"
+         style="fill:none;stroke:#000000;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker2091);marker-end:url(#marker2473)" />
+    </g>
+  </g>
+</svg>

--- a/python/emach/model_obj/cross_sects/inner_rotor_stator/README.md
+++ b/python/emach/model_obj/cross_sects/inner_rotor_stator/README.md
@@ -1,0 +1,3 @@
+# Inner Rotor Stator Cross Section
+
+<img src="./CrossSectInnerRotorStator.svg" width="950" height="950" />

--- a/python/emach/model_obj/cross_sects/inner_rotor_stator/__init__.py
+++ b/python/emach/model_obj/cross_sects/inner_rotor_stator/__init__.py
@@ -1,0 +1,240 @@
+
+import numpy as np
+
+from ...dimensions import DimRadian
+from ...dimensions.dim_linear import DimLinear
+from ...dimensions.dim_angular import DimAngular
+from ..cross_sect_base import CrossSectBase, CrossSectToken
+
+__all__ = ['CrossSectInnerRotorStator']
+class CrossSectInnerRotorStator(CrossSectBase):
+    
+    def __init__(self, **kwargs: any) -> None: 
+        '''
+        Intialization function for HollowCylinder class. This function takes in
+        arguments and saves the information passed to private variable to make
+        them read-only
+        Parameters
+        ----------
+        **kwargs : any
+            DESCRIPTION. Keyword arguments provided to the initialization funcntion.
+            The following argument names have to be included in order for the code
+            to execute: name, dim_t, dim_r_o, location. 
+            
+        Returns
+        -------
+        None
+        '''
+        self._create_attr(kwargs)  
+        
+        super()._validate_attr()
+        self._validate_attr()
+    
+    @property
+    def dim_alpha_st(self):
+        return self._dim_alpha_st
+    
+    @property
+    def dim_alpha_so(self):
+        return self._dim_alpha_so
+    
+    @property
+    def dim_r_si(self):
+        return self._dim_r_si
+    
+    @property
+    def dim_d_so(self):
+        return self._dim_d_so
+    
+    @property
+    def dim_d_sp(self):
+        return self._dim_d_sp
+    
+    @property
+    def dim_d_st(self):
+        return self._dim_d_st
+    
+    @property
+    def dim_d_sy(self):
+        return self._dim_d_sy
+    
+    @property
+    def dim_w_st(self):
+        return self._dim_w_st
+    
+    @property
+    def dim_r_st(self):
+        return self._dim_r_st
+    
+    @property
+    def dim_r_sf(self):
+        return self._dim_r_sf
+    
+    @property
+    def dim_r_sb(self):
+        return self._dim_r_sb
+    
+    @property
+    def Q(self):
+        return self._Q
+
+    
+    def draw(self, drawer):
+
+        alpha_st = DimRadian(self.dim_alpha_st)
+        alpha_so = DimRadian(self.dim_alpha_so)
+        r_si = self.dim_r_si
+        d_so = self.dim_d_so
+        d_sp = self.dim_d_sp
+        d_st = self.dim_d_st
+        d_sy = self.dim_d_sy
+        w_st = self.dim_w_st
+        r_st = self.dim_r_st
+        r_sf = self.dim_r_sf
+        r_sb = self.dim_r_sb
+        Q = self.Q
+        
+        alpha_total = DimRadian(2*np.pi/Q)
+        
+        x1 = r_si*np.cos(alpha_st/2)
+        beta2 = alpha_st/2 - alpha_so
+        x2 = x1 + d_so*np.cos( beta2 )
+        r3 = r_si + d_sp
+        beta3 = np.arcsin((w_st/2)/r3)
+        x3 = r3*np.cos(beta3)
+        r4 = r3 + d_st
+        beta4 = np.arcsin((w_st/2)/r4)
+        x4 = r4*np.cos(beta4)
+        x5 = r4*np.cos(alpha_total/2)
+        x6 = (r4 + d_sy)*np.cos(alpha_total/2)
+        
+        y1 = r_si*np.sin(alpha_st/2)
+        y2 = y1 + d_so*np.sin(beta2)
+        y3 = w_st/2
+        y4 = w_st/2
+        y5 = r4*np.sin(alpha_total/2)
+        y6 = (r4 + d_sy)*np.sin(alpha_total/2)
+        
+        x_arr = [ x1, x1, x2, x3, x4, x5, x6, x6, x5, x4, x3, x2 ]
+        y_arr = [-y1, y1, y2, y3, y4, y5, y6, -y6, -y5, -y4, -y3, -y2]
+        
+        arc1 = []
+        arc2 = []
+        arc3 = []
+        arc4 = []
+        seg1 = []
+        seg2 = []
+        seg3 = []
+        seg4 = []
+        seg5 = []
+        seg6 = []
+        
+        z = np.array([x_arr, y_arr])
+        
+        coords = np.transpose(z)# convert coordinates to a form of [[x1,y1]..]
+        
+        for i in range(0,Q):
+          
+            p = self.location.transform_coords(coords, alpha_total*i)
+            
+            x = p[:,0]
+            y = p[:,1]
+        
+            p1 = [x[0], y[0]]
+            p2 = [x[1], y[1]]
+            p3 = [x[2], y[2]]
+            p4 = [x[3], y[3]]
+            p5 = [x[4], y[4]]
+            p6 = [x[5], y[5]]
+            p7 = [x[6], y[6]]
+            p8 = [x[7], y[7]]
+            p9 = [x[8], y[8]]
+            p10 = [x[9], y[9]]
+            p11 = [x[10], y[10]]
+            p12 = [x[11], y[11]]
+
+            arc1.append(drawer.draw_arc(self.location.anchor_xy, p1, p2))
+            seg1.append(drawer.draw_line(p2, p3))
+            seg2.append(drawer.draw_line(p3, p4))
+            seg3.append(drawer.draw_line(p4, p5))
+            arc2.append(drawer.draw_arc(self.location.anchor_xy, p5, p6))
+            arc3.append(drawer.draw_arc(self.location.anchor_xy, p8, p7))
+            arc4.append(drawer.draw_arc(self.location.anchor_xy, p9, p10))
+            seg4.append(drawer.draw_line(p10, p11))
+            seg5.append(drawer.draw_line(p11, p12))
+            seg6.append(drawer.draw_line(p12, p1))
+        
+        rad = (x3 + x4)/2
+        inner_coord = self.location.transform_coords(np.array([[rad, 0]]))
+        segments = [arc1, seg1, seg2, seg3, arc2, arc3, arc4, seg4, seg5, seg6]
+        cs_token = CrossSectToken(inner_coord[0,:], segments)
+        return cs_token
+        
+    def _validate_attr(self):
+        
+        if isinstance(self._dim_alpha_st, DimAngular):
+            pass
+        else:
+            raise TypeError("dim_alpha_st not of type DimAngular")
+            
+        if isinstance(self._dim_alpha_so, DimAngular):
+            pass
+        else:
+            raise TypeError("dim_alpha_so not of type DimAngular")  
+        
+        if isinstance(self._dim_r_si, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_si not of type DimLinear") 
+            
+        if isinstance(self._dim_d_so, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_so not of type DimLinear") 
+        
+        if isinstance(self._dim_d_sp, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_sp not of type DimLinear") 
+            
+        if isinstance(self._dim_d_st, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_st not of type DimLinear") 
+            
+        if isinstance(self._dim_d_sy, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_d_sy not of type DimLinear") 
+            
+        if isinstance(self._dim_w_st, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_w_st not of type DimLinear") 
+        
+        if isinstance(self._dim_r_sf, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_sf not of type DimLinear") 
+        
+        if isinstance(self._dim_r_st, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_st not of type DimLinear") 
+        
+        if isinstance(self._dim_r_sb, DimLinear):
+            pass
+        else:
+            raise TypeError("dim_r_sb not of type DimLinear") 
+        
+        if isinstance(self._Q, int):
+            pass
+        else:
+            raise TypeError("Q not of type int") 
+            
+            
+        
+            
+            
+            
+            

--- a/python/examples/example_inner_rotor_stator_cross.py
+++ b/python/examples/example_inner_rotor_stator_cross.py
@@ -1,0 +1,40 @@
+# add the directory immediately above this file's directory to path for module import
+import sys
+sys.path.append("..")
+
+import emach.tools.magnet as mn
+import emach.model_obj as mo
+import numpy as np
+
+x = mo.DimMillimeter(4)
+y = mo.DimMillimeter(80)
+z = mo.DimMillimeter(40)
+
+
+stator4 = mo.CrossSectInnerRotorStator( name = 'stator1', 
+                                        dim_alpha_st = mo.DimDegree(40), 
+                                        dim_alpha_so = mo.DimDegree(20), 
+                                        dim_r_si = mo.DimMillimeter(40), 
+                                        dim_d_so = mo.DimMillimeter(5), 
+                                        dim_d_sp = mo.DimMillimeter(10), 
+                                        dim_d_st = mo.DimMillimeter(15), 
+                                        dim_d_sy = mo.DimMillimeter(15), 
+                                        dim_w_st = mo.DimMillimeter(13), 
+                                        dim_r_st = mo.DimMillimeter(0), 
+                                        dim_r_sf = mo.DimMillimeter(0), 
+                                        dim_r_sb = mo.DimMillimeter(0), 
+                                        Q = 6,
+                                        location = mo.Location2D())
+
+
+# create an instance of the MagNet class
+toolMn = mn.MagNet(visible=True)
+toolMn.open()
+
+# draw hollowcylinders
+c1 = stator4.draw(toolMn)
+
+toolMn.view_all()
+# select inner coordinate of a hollow cylinder
+toolMn.prepare_section(c1)
+


### PR DESCRIPTION
This PR adds inner rotor stator cross-section drawing capability to the `Python` implementation of `eMach`. The example script corresponding to this cross-section is `python/examples/example_inner_rotor_stator_cross.py`